### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -90,7 +90,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "650b40ba678898c753ea0857e8ceff5f86fdb64c"
+      "pinned_sha": "d4b1c7fe1a347705f709dad38399d72e751e108d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -123,7 +123,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "650b40ba678898c753ea0857e8ceff5f86fdb64c"
+      "pinned_sha": "d4b1c7fe1a347705f709dad38399d72e751e108d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -154,7 +154,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "650b40ba678898c753ea0857e8ceff5f86fdb64c"
+      "pinned_sha": "d4b1c7fe1a347705f709dad38399d72e751e108d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "38f600f46d26b89c423ef82c233e5dd0e51be17e"
+      "pinned_sha": "2eb280ed2022ddab628051fa0e8fc47808709c0f"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -352,7 +352,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "5c50540470574b6e28ff74dcdaf04ef6439cb48b"
+      "pinned_sha": "87c001cdbd5e0d9a704deb1f30b1de8ff17b14d6"
     }
   ]
 }

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -90,7 +90,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "650b40ba678898c753ea0857e8ceff5f86fdb64c"
+      "pinned_sha": "d4b1c7fe1a347705f709dad38399d72e751e108d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -123,7 +123,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "650b40ba678898c753ea0857e8ceff5f86fdb64c"
+      "pinned_sha": "d4b1c7fe1a347705f709dad38399d72e751e108d"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -154,7 +154,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "650b40ba678898c753ea0857e8ceff5f86fdb64c"
+      "pinned_sha": "d4b1c7fe1a347705f709dad38399d72e751e108d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "38f600f46d26b89c423ef82c233e5dd0e51be17e"
+      "pinned_sha": "2eb280ed2022ddab628051fa0e8fc47808709c0f"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -352,7 +352,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "5c50540470574b6e28ff74dcdaf04ef6439cb48b"
+      "pinned_sha": "87c001cdbd5e0d9a704deb1f30b1de8ff17b14d6"
     }
   ]
 }


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 5
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22284460973
- Merge strategy: squash auto-merge