### PR TITLE
Adjust governance contract token/permission strategy

### DIFF
--- a/.github/workflows/governance-contract.yml
+++ b/.github/workflows/governance-contract.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Validate governance contract
         shell: pwsh
         env:
+          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File ./.github/scripts/Invoke-GovernanceContract.ps1 `


### PR DESCRIPTION
## Summary
- prefer `GH_ADMIN_TOKEN` when present for branch-protection API checks
- keep `github.token` fallback for baseline execution
- degrade gracefully (warning + skip) on 403 "Resource not accessible by integration" instead of hard-failing unrelated PR checks

## Why
`Governance Contract` currently fails in this repo because `github.token` cannot read branch-protection settings (HTTP 403) in this context.

## Changes
- `.github/scripts/Invoke-GovernanceContract.ps1`
  - token-source selection: `GH_ADMIN_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`
  - explicit token-required validation
  - graceful skip on branch-protection API authorization failures
- `.github/workflows/governance-contract.yml`
  - pass both `GH_ADMIN_TOKEN` secret and `github.token` fallback to script

## Operator note
For strict branch-protection enforcement in this workflow, configure repository secret `GH_ADMIN_TOKEN` with repository administration read access.