### PR TITLE
Harden token and permission strategy for governance automation

### DIFF
--- a/.github/scripts/Invoke-GovernanceContract.ps1
+++ b/.github/scripts/Invoke-GovernanceContract.ps1
@@ -14,6 +14,9 @@ $tokenSource = ''
 if (-not [string]::IsNullOrWhiteSpace($env:GH_ADMIN_TOKEN)) {
     $env:GH_TOKEN = $env:GH_ADMIN_TOKEN
     $tokenSource = 'GH_ADMIN_TOKEN'
+} elseif (-not [string]::IsNullOrWhiteSpace($env:WORKFLOW_BOT_TOKEN)) {
+    $env:GH_TOKEN = $env:WORKFLOW_BOT_TOKEN
+    $tokenSource = 'WORKFLOW_BOT_TOKEN'
 } elseif (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
     $tokenSource = 'GH_TOKEN'
 } elseif (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
@@ -31,7 +34,7 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw 'gh CLI is required.'
 }
 if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
-    throw 'GH token is required. Set GH_ADMIN_TOKEN (preferred) or GH_TOKEN/GITHUB_TOKEN.'
+    throw 'GH token is required. Set GH_ADMIN_TOKEN (preferred) or WORKFLOW_BOT_TOKEN/GH_TOKEN/GITHUB_TOKEN.'
 }
 
 $requiredContexts = @(

--- a/.github/workflows/governance-contract.yml
+++ b/.github/workflows/governance-contract.yml
@@ -22,6 +22,7 @@ jobs:
         shell: pwsh
         env:
           GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          WORKFLOW_BOT_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
           GH_TOKEN: ${{ github.token }}
         run: |
           pwsh -NoProfile -File ./.github/scripts/Invoke-GovernanceContract.ps1 `

--- a/.github/workflows/workspace-sha-drift-signal.yml
+++ b/.github/workflows/workspace-sha-drift-signal.yml
@@ -16,10 +16,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate workflow bot token
+        shell: pwsh
+        env:
+          WORKFLOW_BOT_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:WORKFLOW_BOT_TOKEN)) {
+            throw "Required secret WORKFLOW_BOT_TOKEN is not configured. Add a token with repository read access for governed repos."
+          }
+
       - name: Run manifest drift signal
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_BOT_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN }}
         run: |
           $ErrorActionPreference = 'Stop'
           $reportPath = Join-Path $env:RUNNER_TEMP 'workspace-sha-drift-report.json'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This repository is the canonical policy and manifest surface for deterministic `
 ## Release Signal Contract
 - `Workspace SHA Refresh PR` is the primary path for updating `pinned_sha` values.
 - On drift, automation must update manifest pins, create/update branch `automation/sha-refresh`, and open or update a PR to `main`.
+- `workspace-sha-drift-signal.yml` uses `WORKFLOW_BOT_TOKEN` for cross-repo default-branch SHA reads.
 - `workspace-sha-refresh-pr.yml` requires repository secret `WORKFLOW_BOT_TOKEN` for branch mutation, PR operations, and workflow dispatch.
 - If `WORKFLOW_BOT_TOKEN` is missing or misconfigured, refresh automation must fail fast with explicit remediation.
 - Auto-merge is enabled by default for refresh PRs using squash strategy.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Auto-refresh policy:
 1. Auto-merge is enabled by default for refresh PRs with squash strategy.
 2. Maintainer approval is not required for `labview-cdev-surface` refresh merges (`required_approving_review_count = 0`).
 3. Required status checks remain strict (`CI Pipeline`, `Workspace Installer Contract`, `Reproducibility Contract`, `Provenance Contract`).
-4. `workspace-sha-refresh-pr.yml` requires repository secret `WORKFLOW_BOT_TOKEN` for branch mutation, PR operations, and workflow dispatch.
-5. If `WORKFLOW_BOT_TOKEN` is missing or misconfigured, refresh automation fails fast with an explicit error.
-6. Manual refresh PR flow is fallback only for platform outages, not routine check propagation.
+4. `workspace-sha-drift-signal.yml` uses `WORKFLOW_BOT_TOKEN` for cross-repo default-branch SHA reads.
+5. `workspace-sha-refresh-pr.yml` requires repository secret `WORKFLOW_BOT_TOKEN` for branch mutation, PR operations, and workflow dispatch.
+6. If `WORKFLOW_BOT_TOKEN` is missing or misconfigured, refresh automation fails fast with an explicit error.
+7. Manual refresh PR flow is fallback only for platform outages, not routine check propagation.
 
 ## Local checks
 

--- a/scripts/Update-WorkspaceManifestPins.ps1
+++ b/scripts/Update-WorkspaceManifestPins.ps1
@@ -14,9 +14,21 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN) -and -not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
-    $env:GH_TOKEN = $env:GITHUB_TOKEN
+function Initialize-GhToken {
+    if (-not [string]::IsNullOrWhiteSpace($env:WORKFLOW_BOT_TOKEN)) {
+        $env:GH_TOKEN = $env:WORKFLOW_BOT_TOKEN
+        return 'WORKFLOW_BOT_TOKEN'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
+        return 'GH_TOKEN'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+        $env:GH_TOKEN = $env:GITHUB_TOKEN
+        return 'GITHUB_TOKEN'
+    }
+    return ''
 }
+$tokenSource = Initialize-GhToken
 
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw "Required command 'gh' was not found on PATH."
@@ -108,6 +120,7 @@ $report = [ordered]@{
     timestamp_utc = (Get-Date).ToUniversalTime().ToString('o')
     manifest_path = $resolvedManifestPath
     output_path = $resolvedOutputPath
+    token_source = $tokenSource
     write_changes = [bool]$WriteChanges
     status = $status
     changed = ($changes.Count -gt 0)

--- a/tests/WorkspaceManifestPinRefreshScript.Tests.ps1
+++ b/tests/WorkspaceManifestPinRefreshScript.Tests.ps1
@@ -32,6 +32,8 @@ Describe 'Workspace manifest pin refresh script contract' {
         $script:scriptContent | Should -Match 'repos/\$repoSlug/commits/\$encodedBranch'
         $script:scriptContent | Should -Match 'ConvertTo-Json -Depth 12'
         $script:scriptContent | Should -Match 'workspace-sha-refresh-report\.json'
+        $script:scriptContent | Should -Match 'Initialize-GhToken'
+        $script:scriptContent | Should -Match 'token_source'
     }
 
     It 'has parse-safe PowerShell syntax' {

--- a/tests/WorkspaceShaDriftSignalContract.Tests.ps1
+++ b/tests/WorkspaceShaDriftSignalContract.Tests.ps1
@@ -37,6 +37,12 @@ Describe 'Workspace SHA drift signal contract' {
         $script:scriptContent | Should -Match '--jq ''\.sha'''
     }
 
+    It 'uses workflow bot token strategy for cross-repo drift lookup' {
+        $script:workflowContent | Should -Match 'WORKFLOW_BOT_TOKEN:\s*\$\{\{\s*secrets\.WORKFLOW_BOT_TOKEN\s*\}\}'
+        $script:workflowContent | Should -Match 'GH_TOKEN:\s*\$\{\{\s*secrets\.WORKFLOW_BOT_TOKEN\s*\}\}'
+        $script:scriptContent | Should -Match 'Initialize-GhToken'
+    }
+
     It 'uploads drift report artifacts' {
         $script:workflowContent | Should -Match 'workspace-sha-drift-report-\$\{\{\s*github\.run_id\s*\}\}'
         $script:workflowContent | Should -Match 'Upload drift report'


### PR DESCRIPTION
## Summary
- add deterministic token precedence in governance/drift scripts (WORKFLOW_BOT_TOKEN before fallback tokens)
- wire WORKFLOW_BOT_TOKEN into drift and governance-contract workflows while retaining GH_ADMIN_TOKEN for branch-protection reads
- document token expectations in AGENTS.md and README.md
- extend contract tests to enforce the drift token strategy and token-source reporting

## Validation
- Invoke-Pester -Path ./tests/WorkspaceShaDriftSignalContract.Tests.ps1,./tests/WorkspaceManifestPinRefreshScript.Tests.ps1,./tests/WorkspaceShaRefreshPrContract.Tests.ps1,./tests/WorkspaceSurfaceContract.Tests.ps1 -CI -Output Detailed
