### PR TITLE
Stabilize LabVIEW image gates for Windows and Linux runners

### DIFF
--- a/.github/workflows/linux-labview-image-gate.yml
+++ b/.github/workflows/linux-labview-image-gate.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Switch to Docker Desktop Linux engine
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchLinuxEngine
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to switch Docker to Linux engine.'
+          }
+
       - name: Run linux LabVIEW image gate
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ On failure, it updates a single tracking issue (`Nightly Supply-Chain Canary Fai
 `windows-labview-image-gate.yml` is dispatch-only in phase 1 and targets a dedicated self-hosted Windows runner with Windows containers.  
 The gate image is selectable at dispatch via input `labview_windows_image`, with default pinned to the known-working digest (`nationalinstruments/labview@sha256:57c453dabd2ff0185ce718d88704921bb82eb83189f4049205ed9b4da7df7bcd`).  
 It pulls one selected image, installs the NSIS workspace installer in-container, runs bundled `runner-cli ppl build` against container-compatible LabVIEW contracts (`.lvcontainer` is authoritative for both execution year and source version in container mode), and enforces post-action report checks.
+For legacy `runner-cli` compatibility in container runs, the installer applies an in-worktree `.lvversion` shim to the resolved container source version and records that action in `labview_version_resolution.lvversion_container_shim`.
 
 For current gate reliability in this image profile, VIP harness execution is intentionally skipped via policy (`LVIE_SKIP_VIP_HARNESS=1`) and reported as `skipped`.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ For current gate reliability in this image profile, VIP harness execution is int
 
 `linux-labview-image-gate.yml` is dispatch-only and targets the self-hosted Windows runner with Docker Desktop Linux context.
 The gate image is selectable at dispatch via input `labview_linux_image`, with default set to the known-working tag (`nationalinstruments/labview:2026q1-linux`).
+The workflow explicitly switches Docker Desktop to Linux engine before gate execution.
 It uses one selected Linux LabVIEW image and runs `Invoke-DockerDesktopLinuxIteration.ps1` with manifest-pinned `runner-cli` bundle checks in container mode.
 
 Artifacts include `docker-linux-iteration-report.json` and the full gate output under `artifacts/linux-image-gate`.

--- a/scripts/Install-WorkspaceFromManifest.ps1
+++ b/scripts/Install-WorkspaceFromManifest.ps1
@@ -1085,15 +1085,9 @@ try {
             } else {
                 $warnings += "Container execution detected but .lvcontainer could not resolve an execution year. $([string]$containerContract.message)"
                 Write-InstallerFeedback -Message ("Container LabVIEW contract warning: {0}" -f [string]$containerContract.message)
-
-                $sourceVersionRaw = Get-LabVIEWSourceVersionFromRepo -RepoRoot $iconEditorRepoPath
-                if (-not [string]::IsNullOrWhiteSpace($sourceVersionRaw)) {
-                    $runnerCliLabviewVersion = [string]$sourceVersionRaw
-                    $labviewVersionResolution.runner_cli_labview_version = [string]$runnerCliLabviewVersion
-                    $warnings += "Container execution fell back to '.lvversion' source contract because .lvcontainer was unresolved."
-                } else {
-                    $warnings += "LabVIEW source version file '.lvversion' was not found at '$iconEditorRepoPath'; runner-cli will use execution year '$requiredLabviewYear' as source version."
-                }
+                $runnerCliLabviewVersion = [string]$requiredLabviewYear
+                $labviewVersionResolution.runner_cli_labview_version = [string]$runnerCliLabviewVersion
+                $warnings += "Container execution kept runner-cli source version pinned to execution year '$requiredLabviewYear' because .lvcontainer was unresolved. .lvversion is not used in container execution."
             }
         } else {
             $sourceVersionRaw = Get-LabVIEWSourceVersionFromRepo -RepoRoot $iconEditorRepoPath

--- a/scripts/Invoke-DockerDesktopLinuxIteration.ps1
+++ b/scripts/Invoke-DockerDesktopLinuxIteration.ps1
@@ -136,7 +136,7 @@ if ($SkipPester) {
     $containerScriptPathUsed = $containerScriptHostPathSh
     $containerScriptContent = @"
 #!/bin/sh
-set -eu
+set -e
 
 runner_cli_source='/bundle/runner-cli.exe'
 if [ ! -f "`$runner_cli_source" ]; then
@@ -164,7 +164,8 @@ cat > /hostout/container-report.json <<JSON
 }
 JSON
 "@
-    Set-Content -LiteralPath $containerScriptHostPathSh -Value $containerScriptContent -Encoding utf8
+    $containerScriptContent = $containerScriptContent -replace "`r`n", "`n"
+    [System.IO.File]::WriteAllText($containerScriptHostPathSh, $containerScriptContent, (New-Object System.Text.UTF8Encoding($false)))
     $containerEntryPoint = @('sh', '/hostout/container-run.sh')
 } else {
     $containerScriptPathUsed = $containerScriptHostPathPs1

--- a/tests/DockerDesktopLinuxIterationContract.Tests.ps1
+++ b/tests/DockerDesktopLinuxIterationContract.Tests.ps1
@@ -19,6 +19,8 @@ Describe 'Docker Desktop Linux iteration contract' {
         $script:scriptContent | Should -Match '\[string\]\$DockerContext\s*=\s*''desktop-linux'''
         $script:scriptContent | Should -Match 'Resolve-DockerContextForLinuxIteration'
         $script:scriptContent | Should -Match 'requested_docker_context'
+        $script:scriptContent | Should -Match 'container-run\.sh'
+        $script:scriptContent | Should -Match '''sh'', ''/hostout/container-run\.sh'''
         $script:scriptContent | Should -Match 'runner-cli\.exe'
         $script:scriptContent | Should -Match 'docker run'
         $script:scriptContent | Should -Match '--context'

--- a/tests/DockerDesktopLinuxIterationContract.Tests.ps1
+++ b/tests/DockerDesktopLinuxIterationContract.Tests.ps1
@@ -17,6 +17,8 @@ Describe 'Docker Desktop Linux iteration contract' {
         $script:scriptContent | Should -Match 'Build-RunnerCliBundleFromManifest\.ps1'
         $script:scriptContent | Should -Match '\[string\]\$Runtime\s*=\s*''linux-x64'''
         $script:scriptContent | Should -Match '\[string\]\$DockerContext\s*=\s*''desktop-linux'''
+        $script:scriptContent | Should -Match 'Resolve-DockerContextForLinuxIteration'
+        $script:scriptContent | Should -Match 'requested_docker_context'
         $script:scriptContent | Should -Match 'runner-cli\.exe'
         $script:scriptContent | Should -Match 'docker run'
         $script:scriptContent | Should -Match '--context'

--- a/tests/LinuxLabviewImageGateWorkflowContract.Tests.ps1
+++ b/tests/LinuxLabviewImageGateWorkflowContract.Tests.ps1
@@ -23,6 +23,8 @@ Describe 'Linux LabVIEW image gate workflow contract' {
 
     It 'uses a single LabVIEW linux image and desktop-linux docker context' {
         $script:workflowContent | Should -Match 'LABVIEW_LINUX_IMAGE:\s*\$\{\{\s*inputs\.labview_linux_image\s*\}\}'
+        $script:workflowContent | Should -Match 'Switch to Docker Desktop Linux engine'
+        $script:workflowContent | Should -Match 'DockerCli\.exe.*-SwitchLinuxEngine'
         $script:workflowContent | Should -Match 'Invoke-DockerDesktopLinuxIteration\.ps1'
         $script:workflowContent | Should -Match '-Image \$env:LABVIEW_LINUX_IMAGE'
         $script:workflowContent | Should -Match "-DockerContext 'desktop-linux'"

--- a/tests/WorkspaceInstallRuntimeContract.Tests.ps1
+++ b/tests/WorkspaceInstallRuntimeContract.Tests.ps1
@@ -42,6 +42,8 @@ Describe 'Workspace install runtime contract' {
         $script:scriptContent | Should -Match 'Get-LabVIEWSourceVersionFromRepo'
         $script:scriptContent | Should -Match 'runner_cli_labview_version'
         $script:scriptContent | Should -Match '\.lvversion is ignored in container execution'
+        $script:scriptContent | Should -Match '\.lvversion is not used in container execution'
+        $script:scriptContent | Should -Not -Match "fell back to '\.lvversion' source contract"
         $script:scriptContent | Should -Match 'source_contract=.lvcontainer'
         $script:scriptContent | Should -Match 'LVIE_INSTALLER_CONTAINER_MODE'
         $script:scriptContent | Should -Match 'LVIE_SKIP_VIP_HARNESS'

--- a/tests/WorkspaceInstallRuntimeContract.Tests.ps1
+++ b/tests/WorkspaceInstallRuntimeContract.Tests.ps1
@@ -40,10 +40,13 @@ Describe 'Workspace install runtime contract' {
         $script:scriptContent | Should -Match 'Get-LabVIEWContainerExecutionContract'
         $script:scriptContent | Should -Match '\.lvcontainer'
         $script:scriptContent | Should -Match 'Get-LabVIEWSourceVersionFromRepo'
+        $script:scriptContent | Should -Match 'Set-LabVIEWSourceVersionInRepo'
         $script:scriptContent | Should -Match 'runner_cli_labview_version'
         $script:scriptContent | Should -Match '\.lvversion is ignored in container execution'
         $script:scriptContent | Should -Match '\.lvversion is not used in container execution'
         $script:scriptContent | Should -Not -Match "fell back to '\.lvversion' source contract"
+        $script:scriptContent | Should -Match 'lvversion_container_shim'
+        $script:scriptContent | Should -Match 'Container source version shim status='
         $script:scriptContent | Should -Match 'source_contract=.lvcontainer'
         $script:scriptContent | Should -Match 'LVIE_INSTALLER_CONTAINER_MODE'
         $script:scriptContent | Should -Match 'LVIE_SKIP_VIP_HARNESS'


### PR DESCRIPTION
## Summary
- make Windows container gate honor container LabVIEW source expectations via installer .lvversion compatibility shim
- make Linux gate switch Docker Desktop engine and add Docker context readiness/fallback resolution
- add shell-based container entrypoint for Linux images that do not include pwsh
- keep image selection as workflow-dispatch inputs with known-good defaults

## Validation
- Windows gate default image succeeded: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22289482803
- Windows gate explicit image input succeeded: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22289484785
- Linux gate default image succeeded: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22289727924

## Notes
- Linux iteration now writes diagnostics even on early failures and can fall back from desktop-linux to default context when needed.
- Container execution in installer keeps .lvcontainer authoritative and applies a local .lvversion shim only for runner-cli compatibility during container runs.