### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -154,7 +154,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "0acb71362bd51838ce73eec30f9365f71f8f5feb"
+      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "967d75513fd038b4bb04d3f0b0490e800ae5c980"
+      "pinned_sha": "13c3afd4935c8008df5ecdfb439e243138a64d16"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -352,7 +352,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "87c001cdbd5e0d9a704deb1f30b1de8ff17b14d6"
+      "pinned_sha": "0f5b2c8213405c2ae2a4398c95315f540937c8ef"
     }
   ]
 }

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -154,7 +154,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "0acb71362bd51838ce73eec30f9365f71f8f5feb"
+      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "967d75513fd038b4bb04d3f0b0490e800ae5c980"
+      "pinned_sha": "13c3afd4935c8008df5ecdfb439e243138a64d16"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -352,7 +352,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "87c001cdbd5e0d9a704deb1f30b1de8ff17b14d6"
+      "pinned_sha": "0f5b2c8213405c2ae2a4398c95315f540937c8ef"
     }
   ]
 }


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 3
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22290307949
- Merge strategy: squash auto-merge