### PR TITLE
Add installer harness self-hosted workflow to fork

### DIFF
--- a/.github/workflows/installer-harness-self-hosted.yml
+++ b/.github/workflows/installer-harness-self-hosted.yml
@@ -1,0 +1,220 @@
+name: Installer Harness
+
+on:
+  push:
+    branches:
+      - integration/**
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Optional branch or SHA to evaluate. Defaults to current workflow ref.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: installer-harness-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  installer-harness:
+    name: Installer Harness
+    runs-on: [self-hosted, windows, self-hosted-windows-lv, installer-harness]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve workflow_dispatch ref override
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != '' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & git fetch --prune origin "${{ inputs.ref }}"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to fetch requested ref '${{ inputs.ref }}'."
+          }
+
+          & git checkout --force FETCH_HEAD
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to checkout requested ref '${{ inputs.ref }}'."
+          }
+
+      - name: Assert runner baseline lock
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runnerWorkspace = [string]$env:RUNNER_WORKSPACE
+          if ([string]::IsNullOrWhiteSpace($runnerWorkspace) -or -not (Test-Path -LiteralPath $runnerWorkspace -PathType Container)) {
+            throw "RUNNER_WORKSPACE is not set to a valid path: '$runnerWorkspace'"
+          }
+          $activeRunnerRoot = Split-Path -Path (Split-Path -Path $runnerWorkspace -Parent) -Parent
+          if ([string]::IsNullOrWhiteSpace($activeRunnerRoot) -or -not (Test-Path -LiteralPath $activeRunnerRoot -PathType Container)) {
+            throw "Unable to resolve active runner root from RUNNER_WORKSPACE '$runnerWorkspace'."
+          }
+
+          $reportPath = Join-Path $env:RUNNER_TEMP 'installer-harness/runner-baseline-report.json'
+          & pwsh -NoProfile -File ./scripts/Assert-InstallerHarnessRunnerBaseline.ps1 `
+            -Repository 'LabVIEW-Community-CI-CD/labview-cdev-surface' `
+            -RunnerRoots @($activeRunnerRoot) `
+            -AllowInteractiveRunner `
+            -OutputPath $reportPath
+          if ($LASTEXITCODE -ne 0) {
+            if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
+              Get-Content -LiteralPath $reportPath -Raw | Write-Host
+            }
+            throw "Runner baseline lock failed."
+          }
+
+      - name: Assert machine preflight pack
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $reportPath = Join-Path $env:RUNNER_TEMP 'installer-harness/machine-preflight-report.json'
+          & pwsh -NoProfile -File ./scripts/Assert-InstallerHarnessMachinePreflight.ps1 `
+            -ExpectedLabviewYear '2020' `
+            -DockerContext 'desktop-linux' `
+            -DockerCheckSeverity warning `
+            -OutputPath $reportPath
+          if ($LASTEXITCODE -ne 0) {
+            if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
+              Get-Content -LiteralPath $reportPath -Raw | Write-Host
+            }
+            throw "Machine preflight checks failed."
+          }
+
+      - name: Run full installer harness iteration
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $toolDirs = @(
+            'C:\Program Files\PowerShell\7',
+            'C:\Program Files\Git\cmd',
+            'C:\Program Files\GitHub CLI',
+            'C:\Program Files\G-CLI\bin',
+            'C:\Program Files\JKI\VI Package Manager\support'
+          )
+          foreach ($toolDir in $toolDirs) {
+            if (-not (Test-Path -LiteralPath $toolDir -PathType Container)) {
+              continue
+            }
+            if ($env:PATH -notlike "*$toolDir*") {
+              $env:PATH = "$toolDir;$env:PATH"
+            }
+          }
+
+          $outputRoot = Join-Path $env:RUNNER_TEMP 'installer-harness'
+          $smokeWorkspaceRoot = Join-Path $env:RUNNER_TEMP 'dev-smoke-lvie'
+          & pwsh -NoProfile -File ./scripts/Invoke-WorkspaceInstallerIteration.ps1 `
+            -Mode full `
+            -Iterations 1 `
+            -OutputRoot $outputRoot `
+            -SmokeWorkspaceRoot $smokeWorkspaceRoot
+          if ($LASTEXITCODE -ne 0) {
+            if (Test-Path -LiteralPath $outputRoot -PathType Container) {
+              Get-ChildItem -LiteralPath $outputRoot -Recurse -File -ErrorAction SilentlyContinue |
+                Select-Object -First 200 FullName, Length, LastWriteTime |
+                Format-Table -AutoSize | Out-String | Write-Host
+            }
+            throw "Installer harness iteration failed."
+          }
+
+      - name: Validate harness reports and post-action gates
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $outputRoot = Join-Path $env:RUNNER_TEMP 'installer-harness'
+          $summaryPath = Join-Path $outputRoot 'iteration-summary.json'
+          if (-not (Test-Path -LiteralPath $summaryPath -PathType Leaf)) {
+            throw "Missing iteration summary: $summaryPath"
+          }
+
+          $summary = Get-Content -LiteralPath $summaryPath -Raw | ConvertFrom-Json -ErrorAction Stop
+          if ([int]$summary.executed_runs -lt 1) {
+            throw "Installer harness executed_runs is < 1."
+          }
+
+          $latestRun = $summary.latest
+          $runOutputRoot = [string]$latestRun.output_root
+          if ([string]::IsNullOrWhiteSpace($runOutputRoot) -or -not (Test-Path -LiteralPath $runOutputRoot -PathType Container)) {
+            throw "Latest run output root is missing: $runOutputRoot"
+          }
+
+          $exerciseReportPath = Join-Path $runOutputRoot 'exercise-report.json'
+          if (-not (Test-Path -LiteralPath $exerciseReportPath -PathType Leaf)) {
+            throw "Missing exercise report: $exerciseReportPath"
+          }
+          $exerciseReport = Get-Content -LiteralPath $exerciseReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+          if ([string]$exerciseReport.release_installer.path -eq '') {
+            throw "Exercise report is missing release installer path."
+          }
+
+          $smokeReportPath = [string]$exerciseReport.smoke_installer.report_path
+          if ([string]::IsNullOrWhiteSpace($smokeReportPath)) {
+            $smokeReportPath = 'C:\dev-smoke-lvie\artifacts\workspace-install-latest.json'
+          }
+          if (-not (Test-Path -LiteralPath $smokeReportPath -PathType Leaf)) {
+            throw "Missing smoke install report: $smokeReportPath"
+          }
+
+          $smokeReport = Get-Content -LiteralPath $smokeReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+          if ([string]$smokeReport.status -ne 'succeeded') {
+            throw "Smoke installer report status was '$($smokeReport.status)'."
+          }
+          if ([string]$smokeReport.ppl_capability_checks.'32'.status -ne 'pass') {
+            throw "PPL 32-bit gate did not pass."
+          }
+          if ([string]$smokeReport.ppl_capability_checks.'64'.status -ne 'pass') {
+            throw "PPL 64-bit gate did not pass."
+          }
+          if ([string]$smokeReport.vip_package_build_check.status -ne 'pass') {
+            throw "VIP package build gate did not pass."
+          }
+
+          $bundleZip = [string]$exerciseReport.bundle.zip_path
+          if ([string]::IsNullOrWhiteSpace($bundleZip) -or -not (Test-Path -LiteralPath $bundleZip -PathType Leaf)) {
+            throw "Installer bundle zip not found: $bundleZip"
+          }
+
+          $validationReportPath = Join-Path $outputRoot 'harness-validation-report.json'
+          [ordered]@{
+            timestamp_utc = (Get-Date).ToUniversalTime().ToString('o')
+            summary_path = $summaryPath
+            exercise_report_path = $exerciseReportPath
+            smoke_report_path = $smokeReportPath
+            bundle_zip = $bundleZip
+            checks = [ordered]@{
+              executed_runs = [int]$summary.executed_runs
+              smoke_status = [string]$smokeReport.status
+              ppl_32 = [string]$smokeReport.ppl_capability_checks.'32'.status
+              ppl_64 = [string]$smokeReport.ppl_capability_checks.'64'.status
+              vip = [string]$smokeReport.vip_package_build_check.status
+            }
+          } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $validationReportPath -Encoding utf8
+          Write-Host "Harness validation report: $validationReportPath"
+
+      - name: Upload installer harness artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-harness-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/installer-harness/iteration-summary.json
+            ${{ runner.temp }}/installer-harness/runner-baseline-report.json
+            ${{ runner.temp }}/installer-harness/machine-preflight-report.json
+            ${{ runner.temp }}/installer-harness/harness-validation-report.json
+            ${{ runner.temp }}/installer-harness/run-001/exercise-report.json
+            ${{ runner.temp }}/installer-harness/run-001/lvie-cdev-workspace-installer-bundle.zip
+            ${{ runner.temp }}/installer-harness/run-001/lvie-cdev-workspace-installer.exe.sha256
+            ${{ runner.temp }}/dev-smoke-lvie/artifacts/workspace-install-latest.json
+            ${{ runner.temp }}/dev-smoke-lvie/artifacts/workspace-installer-launch.log
+            ${{ runner.temp }}/dev-smoke-lvie/labview-icon-editor/builds/status/workspace-installer-vip-build.json
+            ${{ runner.temp }}/dev-smoke-lvie/labview-icon-editor/builds/logs/vipm-build.log
+            ${{ runner.temp }}/dev-smoke-lvie/labview-icon-editor/builds/logs/vipm/**
+          if-no-files-found: warn

--- a/scripts/Assert-InstallerHarnessMachinePreflight.ps1
+++ b/scripts/Assert-InstallerHarnessMachinePreflight.ps1
@@ -1,0 +1,210 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ExpectedLabviewYear = '2020',
+
+    [Parameter()]
+    [string]$DockerContext = 'desktop-linux',
+
+    [Parameter()]
+    [string]$NsisPath = 'C:\Program Files (x86)\NSIS\makensis.exe',
+
+    [Parameter()]
+    [string]$OutputPath = '',
+
+    [Parameter()]
+    [ValidateSet('error', 'warning')]
+    [string]$DockerCheckSeverity = 'error',
+
+    [Parameter()]
+    [switch]$FailOnWarning
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$checks = @()
+$errors = @()
+$warnings = @()
+$resolvedTools = @{}
+
+$toolFallbackMap = @{
+    'pwsh' = @(
+        (Join-Path $PSHOME 'pwsh.exe'),
+        'C:\Program Files\PowerShell\7\pwsh.exe'
+    )
+    'git' = @(
+        'C:\Program Files\Git\cmd\git.exe'
+    )
+    'gh' = @(
+        'C:\Program Files\GitHub CLI\gh.exe'
+    )
+    'g-cli' = @(
+        'C:\Program Files\G-CLI\bin\g-cli.exe'
+    )
+    'vipm' = @(
+        'C:\Program Files\JKI\VI Package Manager\support\vipm.exe'
+    )
+    'docker' = @(
+        'C:\Program Files\Docker\Docker\resources\bin\docker.exe'
+    )
+}
+
+function Add-Check {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][bool]$Passed,
+        [Parameter(Mandatory = $true)][string]$Detail,
+        [Parameter()][ValidateSet('error', 'warning')][string]$Severity = 'error'
+    )
+
+    $entry = [ordered]@{
+        check = $Name
+        passed = $Passed
+        severity = $Severity
+        detail = $Detail
+    }
+    $script:checks += [pscustomobject]$entry
+
+    if (-not $Passed) {
+        if ($Severity -eq 'warning') {
+            $script:warnings += "$Name :: $Detail"
+        } else {
+            $script:errors += "$Name :: $Detail"
+        }
+    }
+}
+
+function Resolve-Tool {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter()][string[]]$FallbackPaths = @()
+    )
+
+    $command = Get-Command $Name -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -ne $command) {
+        return [pscustomobject]@{
+            found = $true
+            path = [string]$command.Source
+            source = 'PATH'
+        }
+    }
+
+    foreach ($fallbackPath in @($FallbackPaths)) {
+        if (-not [string]::IsNullOrWhiteSpace($fallbackPath) -and (Test-Path -LiteralPath $fallbackPath -PathType Leaf)) {
+            return [pscustomobject]@{
+                found = $true
+                path = [string]$fallbackPath
+                source = 'fallback'
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        found = $false
+        path = 'missing'
+        source = 'missing'
+    }
+}
+
+foreach ($commandName in @('pwsh', 'git', 'gh', 'g-cli', 'vipm', 'docker')) {
+    $resolved = Resolve-Tool -Name $commandName -FallbackPaths @($toolFallbackMap[$commandName])
+    $resolvedTools[$commandName] = $resolved
+    $commandDetail = "{0} [{1}]" -f $resolved.path, $resolved.source
+    $severity = if ($commandName -eq 'docker') { $DockerCheckSeverity } else { 'error' }
+    Add-Check `
+        -Name ("command:{0}" -f $commandName) `
+        -Passed ([bool]$resolved.found) `
+        -Detail $commandDetail `
+        -Severity $severity
+}
+
+$nsisResolved = $NsisPath
+if (-not (Test-Path -LiteralPath $nsisResolved -PathType Leaf)) {
+    $makensis = Get-Command makensis -ErrorAction SilentlyContinue
+    if ($null -ne $makensis) {
+        $nsisResolved = $makensis.Source
+    }
+}
+Add-Check `
+    -Name 'command:makensis' `
+    -Passed (Test-Path -LiteralPath $nsisResolved -PathType Leaf) `
+    -Detail $nsisResolved
+
+$labview64 = "C:\Program Files\National Instruments\LabVIEW $ExpectedLabviewYear"
+$labview32 = "C:\Program Files (x86)\National Instruments\LabVIEW $ExpectedLabviewYear"
+Add-Check -Name 'labview:x64' -Passed (Test-Path -LiteralPath $labview64 -PathType Container) -Detail $labview64
+Add-Check -Name 'labview:x86' -Passed (Test-Path -LiteralPath $labview32 -PathType Container) -Detail $labview32
+
+$dockerContextExists = $false
+$dockerContextInspectOutput = ''
+$dockerTool = $resolvedTools['docker']
+if ($null -ne $dockerTool -and [bool]$dockerTool.found) {
+    $dockerContextInspectOutput = (& $dockerTool.path context inspect $DockerContext 2>&1 | Out-String)
+    if ($LASTEXITCODE -eq 0) {
+        $dockerContextExists = $true
+    }
+}
+Add-Check `
+    -Name 'docker:context_exists' `
+    -Passed $dockerContextExists `
+    -Detail ("context={0}" -f $DockerContext) `
+    -Severity $DockerCheckSeverity
+
+$dockerContextReachable = $false
+$dockerInfoDetail = ''
+if ($dockerContextExists) {
+    $dockerInfoOutput = (& $dockerTool.path --context $DockerContext info --format '{{.ServerVersion}}|{{.OSType}}' 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -eq 0) {
+        $dockerContextReachable = $true
+        $dockerInfoDetail = $dockerInfoOutput
+    } else {
+        $dockerInfoDetail = $dockerInfoOutput
+    }
+} else {
+    $dockerInfoDetail = $dockerContextInspectOutput.Trim()
+}
+Add-Check `
+    -Name 'docker:context_reachable' `
+    -Passed $dockerContextReachable `
+    -Detail ("context={0}; detail={1}" -f $DockerContext, $dockerInfoDetail) `
+    -Severity $DockerCheckSeverity
+
+$status = if ($errors.Count -gt 0) { 'failed' } else { 'succeeded' }
+$report = [ordered]@{
+    timestamp_utc = (Get-Date).ToUniversalTime().ToString('o')
+    expected_labview_year = $ExpectedLabviewYear
+    docker_context = $DockerContext
+    nsis_path = $nsisResolved
+    status = $status
+    summary = [ordered]@{
+        checks = $checks.Count
+        errors = $errors.Count
+        warnings = $warnings.Count
+    }
+    checks = $checks
+    errors = $errors
+    warnings = $warnings
+}
+
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $resolvedOutput = [System.IO.Path]::GetFullPath($OutputPath)
+    $outputDir = Split-Path -Path $resolvedOutput -Parent
+    if (-not [string]::IsNullOrWhiteSpace($outputDir) -and -not (Test-Path -LiteralPath $outputDir -PathType Container)) {
+        New-Item -Path $outputDir -ItemType Directory -Force | Out-Null
+    }
+    $report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $resolvedOutput -Encoding utf8
+    Write-Host "Machine preflight report: $resolvedOutput"
+} else {
+    $report | ConvertTo-Json -Depth 8 | Write-Output
+}
+
+if ($errors.Count -gt 0) {
+    exit 1
+}
+if ($FailOnWarning -and $warnings.Count -gt 0) {
+    exit 1
+}
+
+exit 0

--- a/scripts/Assert-InstallerHarnessRunnerBaseline.ps1
+++ b/scripts/Assert-InstallerHarnessRunnerBaseline.ps1
@@ -1,0 +1,259 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Repository = 'LabVIEW-Community-CI-CD/labview-cdev-surface',
+
+    [Parameter()]
+    [string[]]$RunnerRoots = @(
+        'C:\actions-runner-cdev',
+        'C:\actions-runner-cdev-2'
+    ),
+
+    [Parameter()]
+    [string]$ExpectedServiceAccount = 'NT AUTHORITY\NETWORK SERVICE',
+
+    [Parameter()]
+    [switch]$AllowInteractiveRunner,
+
+    [Parameter()]
+    [string[]]$RequiredLabels = @('self-hosted', 'windows', 'self-hosted-windows-lv'),
+
+    [Parameter()]
+    [string]$OutputPath = '',
+
+    [Parameter()]
+    [switch]$FailOnWarning
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$checks = @()
+$errors = @()
+$warnings = @()
+$runnerRootResults = @()
+$serviceResults = @()
+$apiRunnerResults = @()
+
+function Add-Check {
+    param(
+        [Parameter(Mandatory = $true)][string]$Scope,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][bool]$Passed,
+        [Parameter(Mandatory = $true)][string]$Detail,
+        [Parameter()][ValidateSet('error', 'warning')][string]$Severity = 'error'
+    )
+
+    $entry = [ordered]@{
+        scope = $Scope
+        check = $Name
+        passed = $Passed
+        severity = $Severity
+        detail = $Detail
+    }
+    $script:checks += [pscustomobject]$entry
+
+    if (-not $Passed) {
+        if ($Severity -eq 'warning') {
+            $script:warnings += "$Scope::$Name::$Detail"
+        } else {
+            $script:errors += "$Scope::$Name::$Detail"
+        }
+    }
+}
+
+function Normalize-StringArray {
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [string[]]$Values
+    )
+
+    $normalized = @()
+    foreach ($value in @($Values)) {
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            continue
+        }
+
+        foreach ($segment in @(([string]$value) -split ',')) {
+            if ([string]::IsNullOrWhiteSpace($segment)) {
+                continue
+            }
+            $normalized += $segment.Trim()
+        }
+    }
+
+    return @($normalized)
+}
+
+$RunnerRoots = Normalize-StringArray -Values $RunnerRoots
+$RequiredLabels = Normalize-StringArray -Values $RequiredLabels
+
+if ($RunnerRoots.Count -eq 0) {
+    throw "At least one runner root must be provided."
+}
+if ($RequiredLabels.Count -eq 0) {
+    throw "At least one required label must be provided."
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "Required command 'gh' was not found on PATH."
+}
+
+$expectedGitHubUrl = "https://github.com/$Repository"
+
+$serviceInventory = @(Get-CimInstance Win32_Service | Where-Object { $_.Name -like 'actions.runner.LabVIEW-Community-CI-CD-labview-cdev-surface*' })
+$requiredServiceCount = if ($AllowInteractiveRunner.IsPresent) { 0 } else { $RunnerRoots.Count }
+Add-Check -Scope 'services' -Name 'service_count' -Passed ($serviceInventory.Count -ge $requiredServiceCount) -Detail ("count={0}; required_minimum={1}" -f $serviceInventory.Count, $requiredServiceCount)
+
+foreach ($runnerRoot in $RunnerRoots) {
+    $scope = "runner-root:$runnerRoot"
+    $resolvedRoot = [System.IO.Path]::GetFullPath($runnerRoot)
+    $runnerFile = Join-Path $resolvedRoot '.runner'
+    $serviceExe = Join-Path $resolvedRoot 'bin\RunnerService.exe'
+
+    Add-Check -Scope $scope -Name 'root_exists' -Passed (Test-Path -LiteralPath $resolvedRoot -PathType Container) -Detail $resolvedRoot
+    Add-Check -Scope $scope -Name 'runner_file_exists' -Passed (Test-Path -LiteralPath $runnerFile -PathType Leaf) -Detail $runnerFile
+    Add-Check -Scope $scope -Name 'service_exe_exists' -Passed (Test-Path -LiteralPath $serviceExe -PathType Leaf) -Detail $serviceExe
+
+    $runnerData = $null
+    if (Test-Path -LiteralPath $runnerFile -PathType Leaf) {
+        try {
+            $runnerData = Get-Content -LiteralPath $runnerFile -Raw | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            Add-Check -Scope $scope -Name 'runner_json_parse' -Passed $false -Detail $_.Exception.Message
+        }
+    }
+
+    if ($null -ne $runnerData) {
+        $agentName = [string]$runnerData.agentName
+        $runnerRepoUrl = [string]$runnerData.gitHubUrl
+        $runnerRootResults += [pscustomobject]@{
+            root = $resolvedRoot
+            agent_name = $agentName
+            github_url = $runnerRepoUrl
+        }
+
+        Add-Check -Scope $scope -Name 'github_url_matches_repo' -Passed ($runnerRepoUrl -eq $expectedGitHubUrl) -Detail $runnerRepoUrl
+        Add-Check -Scope $scope -Name 'agent_name_present' -Passed (-not [string]::IsNullOrWhiteSpace($agentName)) -Detail $agentName
+
+        $serviceMatch = $serviceInventory |
+            Where-Object { ([string]$_.PathName).Trim('"') -ieq $serviceExe } |
+            Select-Object -First 1
+        if ($null -eq $serviceMatch) {
+            if ($AllowInteractiveRunner.IsPresent) {
+                $listenerExe = Join-Path $resolvedRoot 'bin\Runner.Listener.exe'
+                Add-Check -Scope $scope -Name 'interactive_listener_exists' -Passed (Test-Path -LiteralPath $listenerExe -PathType Leaf) -Detail $listenerExe
+
+                $listenerProcesses = @()
+                try {
+                    $listenerProcesses = @(
+                        Get-CimInstance Win32_Process -Filter "Name='Runner.Listener.exe'" |
+                        Where-Object { ([string]$_.ExecutablePath) -ieq $listenerExe }
+                    )
+                } catch {
+                    Add-Check -Scope $scope -Name 'interactive_runner_process_query' -Passed $false -Detail $_.Exception.Message -Severity warning
+                }
+                Add-Check -Scope $scope -Name 'interactive_runner_process' -Passed ($listenerProcesses.Count -ge 1) -Detail ("count={0}; listener={1}" -f $listenerProcesses.Count, $listenerExe)
+            } else {
+                Add-Check -Scope $scope -Name 'service_mapping' -Passed $false -Detail ("No service mapped to {0}" -f $serviceExe)
+            }
+        } else {
+            $serviceResults += [pscustomobject]@{
+                root = $resolvedRoot
+                service_name = [string]$serviceMatch.Name
+                state = [string]$serviceMatch.State
+                start_mode = [string]$serviceMatch.StartMode
+                start_name = [string]$serviceMatch.StartName
+            }
+            Add-Check -Scope $scope -Name 'service_running' -Passed (([string]$serviceMatch.State) -eq 'Running') -Detail ([string]$serviceMatch.State)
+            Add-Check -Scope $scope -Name 'service_auto_start' -Passed (([string]$serviceMatch.StartMode) -eq 'Auto') -Detail ([string]$serviceMatch.StartMode)
+            Add-Check -Scope $scope -Name 'service_account' -Passed (([string]$serviceMatch.StartName) -eq $ExpectedServiceAccount) -Detail ([string]$serviceMatch.StartName)
+        }
+    }
+}
+
+$apiOutput = & gh api "repos/$Repository/actions/runners" 2>&1
+if ($LASTEXITCODE -ne 0) {
+    $apiErrorText = ($apiOutput | Out-String).Trim()
+    $apiPermissionDenied = (
+        $apiErrorText -match 'Must have admin rights to Repository' -or
+        $apiErrorText -match 'HTTP 403' -or
+        $apiErrorText -match 'Resource not accessible'
+    )
+    $severity = if ($apiPermissionDenied) { 'warning' } else { 'error' }
+    Add-Check -Scope 'github-api' -Name 'runners_query' -Passed $false -Detail $apiErrorText -Severity $severity
+} else {
+    $apiResponse = $apiOutput | ConvertFrom-Json -ErrorAction Stop
+    foreach ($runner in @($apiResponse.runners)) {
+        $labelSet = @($runner.labels | ForEach-Object { [string]$_.name })
+        $apiRunnerResults += [pscustomobject]@{
+            name = [string]$runner.name
+            status = [string]$runner.status
+            busy = [bool]$runner.busy
+            labels = $labelSet
+        }
+    }
+
+    foreach ($runnerRootResult in $runnerRootResults) {
+        $scope = "github-api:$($runnerRootResult.agent_name)"
+        $apiRunner = @($apiRunnerResults | Where-Object { $_.name -eq $runnerRootResult.agent_name } | Select-Object -First 1)
+        if ($null -eq $apiRunner) {
+            Add-Check -Scope $scope -Name 'runner_registered' -Passed $false -Detail 'Runner not found in GitHub API list.'
+            continue
+        }
+
+        Add-Check -Scope $scope -Name 'runner_online' -Passed ($apiRunner.status -eq 'online') -Detail $apiRunner.status
+        foreach ($requiredLabel in $RequiredLabels) {
+            Add-Check `
+                -Scope $scope `
+                -Name ("label:{0}" -f $requiredLabel) `
+                -Passed (@($apiRunner.labels) -contains $requiredLabel) `
+                -Detail ([string]::Join(',', @($apiRunner.labels)))
+        }
+    }
+}
+
+$status = if ($errors.Count -gt 0) { 'failed' } else { 'succeeded' }
+$report = [ordered]@{
+    timestamp_utc = (Get-Date).ToUniversalTime().ToString('o')
+    repository = $Repository
+    expected_github_url = $expectedGitHubUrl
+    expected_runner_roots = $RunnerRoots
+    required_labels = $RequiredLabels
+    expected_service_account = $ExpectedServiceAccount
+    status = $status
+    summary = [ordered]@{
+        checks = $checks.Count
+        errors = $errors.Count
+        warnings = $warnings.Count
+    }
+    checks = $checks
+    runner_roots = $runnerRootResults
+    services = $serviceResults
+    api_runners = $apiRunnerResults
+    errors = $errors
+    warnings = $warnings
+}
+
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $resolvedOutput = [System.IO.Path]::GetFullPath($OutputPath)
+    $outputDir = Split-Path -Path $resolvedOutput -Parent
+    if (-not [string]::IsNullOrWhiteSpace($outputDir) -and -not (Test-Path -LiteralPath $outputDir -PathType Container)) {
+        New-Item -Path $outputDir -ItemType Directory -Force | Out-Null
+    }
+    $report | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $resolvedOutput -Encoding utf8
+    Write-Host "Runner baseline report: $resolvedOutput"
+} else {
+    $report | ConvertTo-Json -Depth 10 | Write-Output
+}
+
+if ($errors.Count -gt 0) {
+    exit 1
+}
+if ($FailOnWarning -and $warnings.Count -gt 0) {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- add .github/workflows/installer-harness-self-hosted.yml from upstream integration harness branch
- add missing harness preflight scripts required by that workflow:
  - scripts/Assert-InstallerHarnessRunnerBaseline.ps1
  - scripts/Assert-InstallerHarnessMachinePreflight.ps1

## Why
Enables running installer harness iteration directly on the fork for faster fork-side validation.

## Validation
- workflow and scripts copied from LabVIEW-Community-CI-CD/labview-cdev-surface ref integration/installer-harness-20260222-d104f15
- branch pushed to fork and ready for dispatch after merge to default branch