### PR TITLE
Fix installer harness runner baseline on fork

### DIFF
--- a/.github/workflows/installer-harness-self-hosted.yml
+++ b/.github/workflows/installer-harness-self-hosted.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Assert runner baseline lock
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN != '' && secrets.WORKFLOW_BOT_TOKEN || github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
           $runnerWorkspace = [string]$env:RUNNER_WORKSPACE
@@ -59,9 +59,10 @@ jobs:
 
           $reportPath = Join-Path $env:RUNNER_TEMP 'installer-harness/runner-baseline-report.json'
           & pwsh -NoProfile -File ./scripts/Assert-InstallerHarnessRunnerBaseline.ps1 `
-            -Repository 'LabVIEW-Community-CI-CD/labview-cdev-surface' `
+            -Repository '${{ github.repository }}' `
             -RunnerRoots @($activeRunnerRoot) `
             -AllowInteractiveRunner `
+            -RequiredLabels @('self-hosted','windows','self-hosted-windows-lv','installer-harness') `
             -OutputPath $reportPath
           if ($LASTEXITCODE -ne 0) {
             if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
@@ -90,7 +91,7 @@ jobs:
       - name: Run full installer harness iteration
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN != '' && secrets.WORKFLOW_BOT_TOKEN || github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
           $toolDirs = @(

--- a/scripts/Assert-InstallerHarnessRunnerBaseline.ps1
+++ b/scripts/Assert-InstallerHarnessRunnerBaseline.ps1
@@ -102,10 +102,12 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
 }
 
 $expectedGitHubUrl = "https://github.com/$Repository"
+$serviceRepoSlug = ($Repository -replace '/', '-')
+$serviceNamePrefix = "actions.runner.$serviceRepoSlug."
 
-$serviceInventory = @(Get-CimInstance Win32_Service | Where-Object { $_.Name -like 'actions.runner.LabVIEW-Community-CI-CD-labview-cdev-surface*' })
+$serviceInventory = @(Get-CimInstance Win32_Service | Where-Object { $_.Name -like "$serviceNamePrefix*" })
 $requiredServiceCount = if ($AllowInteractiveRunner.IsPresent) { 0 } else { $RunnerRoots.Count }
-Add-Check -Scope 'services' -Name 'service_count' -Passed ($serviceInventory.Count -ge $requiredServiceCount) -Detail ("count={0}; required_minimum={1}" -f $serviceInventory.Count, $requiredServiceCount)
+Add-Check -Scope 'services' -Name 'service_count' -Passed ($serviceInventory.Count -ge $requiredServiceCount) -Detail ("count={0}; required_minimum={1}; prefix={2}" -f $serviceInventory.Count, $requiredServiceCount, $serviceNamePrefix)
 
 foreach ($runnerRoot in $RunnerRoots) {
     $scope = "runner-root:$runnerRoot"


### PR DESCRIPTION
## Summary
- make installer-harness workflow use fork-aware repository targeting (github.repository)
- use WORKFLOW_BOT_TOKEN fallback for GH CLI operations in harness steps
- make runner-service discovery in Assert-InstallerHarnessRunnerBaseline.ps1 derive service prefix from -Repository
- require installer-harness label in baseline check

## Why
The harness run queued until labels were added, then failed because baseline checks were hardcoded to upstream service naming and used github.token (403 on runners API). This keeps the workflow runnable on the fork self-hosted runner.