### PR TITLE
Fix installer harness label argument binding

### DIFF
--- a/.github/workflows/installer-harness-self-hosted.yml
+++ b/.github/workflows/installer-harness-self-hosted.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Assert runner baseline lock
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN != '' && secrets.WORKFLOW_BOT_TOKEN || github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
           $runnerWorkspace = [string]$env:RUNNER_WORKSPACE
@@ -59,9 +59,10 @@ jobs:
 
           $reportPath = Join-Path $env:RUNNER_TEMP 'installer-harness/runner-baseline-report.json'
           & pwsh -NoProfile -File ./scripts/Assert-InstallerHarnessRunnerBaseline.ps1 `
-            -Repository 'LabVIEW-Community-CI-CD/labview-cdev-surface' `
+            -Repository '${{ github.repository }}' `
             -RunnerRoots @($activeRunnerRoot) `
             -AllowInteractiveRunner `
+            -RequiredLabels @('self-hosted','windows','self-hosted-windows-lv','installer-harness') `
             -OutputPath $reportPath
           if ($LASTEXITCODE -ne 0) {
             if (Test-Path -LiteralPath $reportPath -PathType Leaf) {
@@ -90,7 +91,7 @@ jobs:
       - name: Run full installer harness iteration
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN != '' && secrets.WORKFLOW_BOT_TOKEN || github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
           $toolDirs = @(

--- a/.github/workflows/installer-harness-self-hosted.yml
+++ b/.github/workflows/installer-harness-self-hosted.yml
@@ -62,7 +62,7 @@ jobs:
             -Repository '${{ github.repository }}' `
             -RunnerRoots @($activeRunnerRoot) `
             -AllowInteractiveRunner `
-            -RequiredLabels @('self-hosted','windows','self-hosted-windows-lv','installer-harness') `
+            -RequiredLabels 'self-hosted,windows,self-hosted-windows-lv,installer-harness' `
             -OutputPath $reportPath
           if ($LASTEXITCODE -ne 0) {
             if (Test-Path -LiteralPath $reportPath -PathType Leaf) {

--- a/scripts/Assert-InstallerHarnessRunnerBaseline.ps1
+++ b/scripts/Assert-InstallerHarnessRunnerBaseline.ps1
@@ -102,10 +102,12 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
 }
 
 $expectedGitHubUrl = "https://github.com/$Repository"
+$serviceRepoSlug = ($Repository -replace '/', '-')
+$serviceNamePrefix = "actions.runner.$serviceRepoSlug."
 
-$serviceInventory = @(Get-CimInstance Win32_Service | Where-Object { $_.Name -like 'actions.runner.LabVIEW-Community-CI-CD-labview-cdev-surface*' })
+$serviceInventory = @(Get-CimInstance Win32_Service | Where-Object { $_.Name -like "$serviceNamePrefix*" })
 $requiredServiceCount = if ($AllowInteractiveRunner.IsPresent) { 0 } else { $RunnerRoots.Count }
-Add-Check -Scope 'services' -Name 'service_count' -Passed ($serviceInventory.Count -ge $requiredServiceCount) -Detail ("count={0}; required_minimum={1}" -f $serviceInventory.Count, $requiredServiceCount)
+Add-Check -Scope 'services' -Name 'service_count' -Passed ($serviceInventory.Count -ge $requiredServiceCount) -Detail ("count={0}; required_minimum={1}; prefix={2}" -f $serviceInventory.Count, $requiredServiceCount, $serviceNamePrefix)
 
 foreach ($runnerRoot in $RunnerRoots) {
     $scope = "runner-root:$runnerRoot"


### PR DESCRIPTION
Pass required labels as one comma-delimited string when invoking Assert-InstallerHarnessRunnerBaseline.ps1 via pwsh -File. This avoids PowerShell argument binding errors from inline array literals in native command invocation.