### PR TITLE
Fix installer harness label argument binding

### DIFF
--- a/.github/workflows/installer-harness-self-hosted.yml
+++ b/.github/workflows/installer-harness-self-hosted.yml
@@ -62,7 +62,7 @@ jobs:
             -Repository '${{ github.repository }}' `
             -RunnerRoots @($activeRunnerRoot) `
             -AllowInteractiveRunner `
-            -RequiredLabels @('self-hosted','windows','self-hosted-windows-lv','installer-harness') `
+            -RequiredLabels 'self-hosted,windows,self-hosted-windows-lv,installer-harness' `
             -OutputPath $reportPath
           if ($LASTEXITCODE -ne 0) {
             if (Test-Path -LiteralPath $reportPath -PathType Leaf) {


### PR DESCRIPTION
Pass required labels as a comma-delimited string when invoking baseline script through pwsh -File to avoid argument binding errors.