### PR TITLE
Fix harness payload runner-cli path for smoke install

### DIFF
--- a/scripts/Build-WorkspaceBootstrapInstaller.ps1
+++ b/scripts/Build-WorkspaceBootstrapInstaller.ps1
@@ -85,8 +85,16 @@ function Resolve-SourceDateEpoch {
         return [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
     }
 
-    $metadataPath = Join-Path $PayloadRoot 'tools\runner-cli\win-x64\runner-cli.metadata.json'
-    if (Test-Path -LiteralPath $metadataPath -PathType Leaf) {
+    $metadataCandidates = @(
+        (Join-Path $PayloadRoot 'tools\runner-cli\win-x64\runner-cli.metadata.json'),
+        (Join-Path $PayloadRoot 'workspace-governance\tools\runner-cli\win-x64\runner-cli.metadata.json')
+    )
+
+    foreach ($metadataPath in $metadataCandidates) {
+        if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
+            continue
+        }
+
         try {
             $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -ErrorAction Stop
             $epoch = 0L

--- a/scripts/Exercise-WorkspaceInstallerLocal.ps1
+++ b/scripts/Exercise-WorkspaceInstallerLocal.ps1
@@ -62,7 +62,7 @@ function Stage-Payload {
     Ensure-Directory -Path $PayloadRoot
     Copy-Item -Path (Join-Path $canonicalPayloadRoot '*') -Destination $PayloadRoot -Recurse -Force
     Ensure-Directory -Path (Join-Path $PayloadRoot 'scripts')
-    Ensure-Directory -Path (Join-Path $PayloadRoot 'tools\runner-cli\win-x64')
+    Ensure-Directory -Path (Join-Path $PayloadRoot 'workspace-governance\tools\runner-cli\win-x64')
 
     Copy-Item -LiteralPath (Join-Path $RepoRoot 'scripts\Install-WorkspaceFromManifest.ps1') -Destination (Join-Path $PayloadRoot 'scripts\Install-WorkspaceFromManifest.ps1') -Force
 }
@@ -137,7 +137,7 @@ if (Test-Path -LiteralPath $smokePayload -PathType Container) { Remove-Item -Lit
 Stage-Payload -RepoRoot $repoRoot -PayloadRoot $canonicalPayload
 & $bundleRunnerCliScript `
     -ManifestPath (Join-Path $canonicalPayload 'workspace-governance\workspace-governance.json') `
-    -OutputRoot (Join-Path $canonicalPayload 'tools\runner-cli\win-x64') `
+    -OutputRoot (Join-Path $canonicalPayload 'workspace-governance\tools\runner-cli\win-x64') `
     -RepoName 'labview-icon-editor' `
     -Runtime 'win-x64'
 if ($LASTEXITCODE -ne 0) {
@@ -146,11 +146,11 @@ if ($LASTEXITCODE -ne 0) {
 
 if (-not $SkipSmokeBuild) {
     Stage-Payload -RepoRoot $repoRoot -PayloadRoot $smokePayload
-    $runnerCliPayloadRoot = Join-Path $canonicalPayload 'tools\runner-cli\win-x64'
+    $runnerCliPayloadRoot = Join-Path $canonicalPayload 'workspace-governance\tools\runner-cli\win-x64'
     foreach ($runnerCliFile in @('runner-cli.exe', 'runner-cli.exe.sha256', 'runner-cli.metadata.json')) {
         Copy-Item `
             -LiteralPath (Join-Path $runnerCliPayloadRoot $runnerCliFile) `
-            -Destination (Join-Path $smokePayload 'tools\runner-cli\win-x64') `
+            -Destination (Join-Path $smokePayload 'workspace-governance\tools\runner-cli\win-x64') `
             -Force
     }
     Convert-ManifestToWorkspace -ManifestPath (Join-Path $smokePayload 'workspace-governance\workspace-governance.json') -WorkspaceRoot $resolvedSmokeRoot


### PR DESCRIPTION
## Fix
- write bundled runner-cli into workspace-governance/tools/runner-cli/win-x64 during installer exercise payload staging
- copy bundled runner-cli into smoke payload at the same path
- allow bootstrap builder to resolve runner-cli metadata from either legacy root path or workspace-governance path

## Why
Installer smoke run resolves payload root from manifest parent (workspace-governance), so runner-cli must be present under that subtree for payload sync and bundle verification.