### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "5ecb8bf99f4c730ac00e9cbb18e581738e63a000"
+      "pinned_sha": "3b24185e2b5ef05e8c3a841dc87df5d8ab5d918d"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "5ecb8bf99f4c730ac00e9cbb18e581738e63a000"
+      "pinned_sha": "3b24185e2b5ef05e8c3a841dc87df5d8ab5d918d"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 1
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22295031040
- Merge strategy: squash auto-merge