### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -90,7 +90,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "f13676e55466628bc87315e9a286fd75be654adf"
+      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -123,7 +123,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "f13676e55466628bc87315e9a286fd75be654adf"
+      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "3b24185e2b5ef05e8c3a841dc87df5d8ab5d918d"
+      "pinned_sha": "fb5e6cbdd851ea0cb2c272dd0d3dd77bb7fea988"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -90,7 +90,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "f13676e55466628bc87315e9a286fd75be654adf"
+      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-org",
@@ -123,7 +123,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "f13676e55466628bc87315e9a286fd75be654adf"
+      "pinned_sha": "b91dc40e4f62399808fe62af1dbf4b1aa7c51160"
     },
     {
       "path": "C:\\dev\\labview-icon-editor-upstream",
@@ -319,7 +319,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "3b24185e2b5ef05e8c3a841dc87df5d8ab5d918d"
+      "pinned_sha": "fb5e6cbdd851ea0cb2c272dd0d3dd77bb7fea988"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 3
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22304779004
- Merge strategy: squash auto-merge