### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -353,7 +353,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "e7688e8e1c7613be839ad365c1dc9e4426d5a5e1"
+      "pinned_sha": "f835eb2fe7d94b7394ad98ab2000f71121448bfa"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -386,7 +386,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "44c5ea0b36ae13d8388e66cffde4d5f54b648f09"
+      "pinned_sha": "f835eb2fe7d94b7394ad98ab2000f71121448bfa"
     }
   ]
 }

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -353,7 +353,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "e7688e8e1c7613be839ad365c1dc9e4426d5a5e1"
+      "pinned_sha": "f835eb2fe7d94b7394ad98ab2000f71121448bfa"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -386,7 +386,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "44c5ea0b36ae13d8388e66cffde4d5f54b648f09"
+      "pinned_sha": "f835eb2fe7d94b7394ad98ab2000f71121448bfa"
     }
   ]
 }


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 2
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/22349498032
- Merge strategy: squash auto-merge