### PR TITLE
Certification lane hardening: dispatch bitness + secondary-32 policy

### DIFF
--- a/tests/MachineCertificationProfilesContract.Tests.ps1
+++ b/tests/MachineCertificationProfilesContract.Tests.ps1
@@ -61,4 +61,22 @@ Describe 'Machine certification setup profile contract' {
             [bool]$property.Value | Should -Be $true
         }
     }
+
+    It 'requires explicit execution bitness policy on active setups' {
+        foreach ($setup in $script:activeSetups) {
+            $property = $setup.PSObject.Properties['execution_bitness']
+            $property | Should -Not -BeNullOrEmpty
+            [string]$property.Value | Should -BeIn @('auto', '32', '64')
+        }
+    }
+
+    It 'requires secondary 32-bit policy only on legacy-2020-desktop-windows' {
+        $legacyWindows = @($script:activeSetups | Where-Object { [string]$_.name -eq 'legacy-2020-desktop-windows' }) | Select-Object -First 1
+        $legacyWindows | Should -Not -BeNullOrEmpty
+        [bool]$legacyWindows.require_secondary_32 | Should -Be $true
+
+        foreach ($setup in @($script:activeSetups | Where-Object { [string]$_.name -ne 'legacy-2020-desktop-windows' })) {
+            [bool]$setup.require_secondary_32 | Should -Be $false
+        }
+    }
 }

--- a/tools/machine-certification/setup-profiles.json
+++ b/tools/machine-certification/setup-profiles.json
@@ -5,7 +5,10 @@
       "name": "legacy-2020-desktop-linux",
       "description": "Windows self-hosted runner with LabVIEW 2020 x86/x64 and Docker desktop-linux context.",
       "setup_route_label": "cert-setup-legacy-2020-desktop-linux",
-      "allowed_machine_names": ["GHOST", "DESKTOP-6Q81H4O"],
+      "allowed_machine_names": [
+        "GHOST",
+        "DESKTOP-6Q81H4O"
+      ],
       "runner_labels_csv": "self-hosted,windows,self-hosted-windows-lv,headless",
       "collision_guard_label": "linux-gate-windows-ready",
       "runner_labels_json": "[\"self-hosted\",\"windows\",\"self-hosted-windows-lv\",\"headless\"]",
@@ -15,13 +18,17 @@
       "switch_docker_context": true,
       "skip_host_ini_mutation": true,
       "skip_override_phase": false,
-      "active": true
+      "active": true,
+      "execution_bitness": "64",
+      "require_secondary_32": false
     },
     {
       "name": "legacy-2020-desktop-windows",
       "description": "Windows self-hosted runner with LabVIEW 2020 x86/x64 and Docker desktop-windows context visibility.",
       "setup_route_label": "cert-setup-legacy-2020-desktop-windows",
-      "allowed_machine_names": ["GHOST"],
+      "allowed_machine_names": [
+        "GHOST"
+      ],
       "runner_labels_csv": "self-hosted,windows,self-hosted-windows-lv,headless",
       "collision_guard_label": "cdev-surface-windows-gate",
       "runner_labels_json": "[\"self-hosted\",\"windows\",\"self-hosted-windows-lv\",\"headless\"]",
@@ -31,13 +38,18 @@
       "switch_docker_context": true,
       "skip_host_ini_mutation": true,
       "skip_override_phase": false,
-      "active": true
+      "active": true,
+      "execution_bitness": "64",
+      "require_secondary_32": true
     },
     {
       "name": "host-2026-desktop-linux",
       "description": "Windows self-hosted runner with LabVIEW 2026 x86/x64 host path checks and Docker desktop-linux context.",
       "setup_route_label": "cert-setup-host-2026-desktop-linux",
-      "allowed_machine_names": ["GHOST", "DESKTOP-6Q81H4O"],
+      "allowed_machine_names": [
+        "GHOST",
+        "DESKTOP-6Q81H4O"
+      ],
       "runner_labels_csv": "self-hosted,windows,self-hosted-windows-lv,headless",
       "collision_guard_label": "linux-gate-windows-ready",
       "runner_labels_json": "[\"self-hosted\",\"windows\",\"self-hosted-windows-lv\",\"headless\"]",
@@ -47,13 +59,17 @@
       "switch_docker_context": true,
       "skip_host_ini_mutation": true,
       "skip_override_phase": false,
-      "active": true
+      "active": true,
+      "execution_bitness": "64",
+      "require_secondary_32": false
     },
     {
       "name": "host-2026-desktop-windows",
       "description": "Windows self-hosted runner with LabVIEW 2026 x86/x64 host path checks and Docker desktop-windows context.",
       "setup_route_label": "cert-setup-host-2026-desktop-windows",
-      "allowed_machine_names": ["GHOST"],
+      "allowed_machine_names": [
+        "GHOST"
+      ],
       "runner_labels_csv": "self-hosted,windows,self-hosted-windows-lv,headless",
       "collision_guard_label": "cdev-surface-windows-gate",
       "runner_labels_json": "[\"self-hosted\",\"windows\",\"self-hosted-windows-lv\",\"headless\"]",
@@ -63,7 +79,9 @@
       "switch_docker_context": true,
       "skip_host_ini_mutation": true,
       "skip_override_phase": false,
-      "active": true
+      "active": true,
+      "execution_bitness": "64",
+      "require_secondary_32": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add explicit execution_bitness and require_secondary_32 policy to machine setup profiles
- propagate those fields through Start-SelfHostedMachineCertification.ps1 workflow dispatch inputs
- include dispatched policy values in the script output report
- add contract coverage for profile policy and dispatch behavior

## Validation
- Invoke-Pester -Path tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1,tests/MachineCertificationProfilesContract.Tests.ps1,tests/StartSelfHostedMachineCertificationContract.Tests.ps1 -CI
