### PR TITLE
CI platform layer v1: portable ops + upload composite + actor-label autofix

### DIFF
--- a/.github/actions/upload-artifact-retry/action.yml
+++ b/.github/actions/upload-artifact-retry/action.yml
@@ -1,0 +1,75 @@
+name: Upload Artifact Retry
+
+description: Upload an artifact with deterministic two-attempt retry and hard fail when both attempts fail.
+
+inputs:
+  artifact_name:
+    description: Artifact name.
+    required: true
+  artifact_path:
+    description: File or directory path to upload.
+    required: true
+  if_no_files_found:
+    description: Behavior when no files are found.
+    required: false
+    default: error
+  retention_days:
+    description: Optional retention days.
+    required: false
+    default: ''
+  compression_level:
+    description: Optional compression level.
+    required: false
+    default: ''
+
+outputs:
+  final_outcome:
+    description: success, retry_success, or failure.
+    value: ${{ steps.finalize.outputs.final_outcome }}
+
+runs:
+  using: composite
+  steps:
+    - id: upload_attempt_1
+      name: Upload artifact (attempt 1)
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_path }}
+        if-no-files-found: ${{ inputs.if_no_files_found }}
+        retention-days: ${{ inputs.retention_days }}
+        compression-level: ${{ inputs.compression_level }}
+
+    - id: upload_attempt_2
+      name: Upload artifact (attempt 2)
+      if: steps.upload_attempt_1.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifact_path }}
+        if-no-files-found: ${{ inputs.if_no_files_found }}
+        retention-days: ${{ inputs.retention_days }}
+        compression-level: ${{ inputs.compression_level }}
+
+    - id: finalize
+      name: Validate artifact upload attempts
+      if: always()
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $attempt1 = '${{ steps.upload_attempt_1.outcome }}'
+        $attempt2 = '${{ steps.upload_attempt_2.outcome }}'
+
+        $finalOutcome = 'failure'
+        if ($attempt1 -eq 'success') {
+          $finalOutcome = 'success'
+        } elseif ($attempt2 -eq 'success') {
+          $finalOutcome = 'retry_success'
+        }
+
+        "final_outcome=$finalOutcome" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+        if ($finalOutcome -eq 'failure') {
+          throw "artifact_upload_failed_after_two_attempts: artifact '${{ inputs.artifact_name }}' could not be uploaded."
+        }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
             './tests/IntegrationGateWorkflowContract.Tests.ps1',
             './tests/SelfHostedMachineCertificationWorkflowContract.Tests.ps1',
             './tests/MachineCertificationProfilesContract.Tests.ps1',
+            './tests/StartSelfHostedMachineCertificationContract.Tests.ps1',
+            './tests/DispatchWorkflowAtRemoteHeadContract.Tests.ps1',
+            './tests/CancelStaleWorkflowRunsContract.Tests.ps1',
+            './tests/WatchWorkflowRunContract.Tests.ps1',
+            './tests/PortableOpsRuntimeContract.Tests.ps1',
+            './tests/VsCodeTasksContract.Tests.ps1',
+            './tests/UploadArtifactRetryCompositeContract.Tests.ps1',
             './tests/InstallerHarnessWorkflowContract.Tests.ps1',
             './tests/NightlySupplyChainCanaryWorkflowContract.Tests.ps1',
             './tests/WindowsLabviewImageGateWorkflowContract.Tests.ps1',
@@ -143,35 +150,13 @@ jobs:
           "asset_path=$assetPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "asset_sha256=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
-      - id: upload-workspace-installer-artifact-attempt-1
-        name: Upload workspace bootstrap installer artifact (attempt 1)
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
+      - id: upload-workspace-installer-artifact
+        name: Upload workspace bootstrap installer artifact
+        uses: ./.github/actions/upload-artifact-retry
         with:
-          name: workspace-bootstrap-installer-${{ github.run_id }}
-          path: ${{ steps.build-workspace-installer.outputs.asset_path }}
-          if-no-files-found: error
-
-      - id: upload-workspace-installer-artifact-attempt-2
-        name: Upload workspace bootstrap installer artifact (attempt 2)
-        if: steps.upload-workspace-installer-artifact-attempt-1.outcome == 'failure'
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: workspace-bootstrap-installer-${{ github.run_id }}
-          path: ${{ steps.build-workspace-installer.outputs.asset_path }}
-          if-no-files-found: error
-
-      - name: Validate workspace bootstrap installer artifact upload
-        if: always()
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $attempt1 = '${{ steps.upload-workspace-installer-artifact-attempt-1.outcome }}'
-          $attempt2 = '${{ steps.upload-workspace-installer-artifact-attempt-2.outcome }}'
-          if ($attempt1 -ne 'success' -and $attempt2 -ne 'success') {
-            throw 'Workspace bootstrap installer artifact upload failed after two attempts.'
-          }
+          artifact_name: workspace-bootstrap-installer-${{ github.run_id }}
+          artifact_path: ${{ steps.build-workspace-installer.outputs.asset_path }}
+          if_no_files_found: error
 
   reproducibility-contract:
     name: Reproducibility Contract
@@ -251,35 +236,13 @@ jobs:
             -NsisRoot $nsisRoot
           if ($LASTEXITCODE -ne 0) { throw 'workspace installer determinism failed.' }
 
-      - id: upload-reproducibility-artifacts-attempt-1
-        name: Upload reproducibility artifacts (attempt 1)
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
+      - id: upload-reproducibility-artifacts
+        name: Upload reproducibility artifacts
+        uses: ./.github/actions/upload-artifact-retry
         with:
-          name: reproducibility-contract-${{ github.run_id }}
-          path: ${{ runner.temp }}/reproducibility
-          if-no-files-found: error
-
-      - id: upload-reproducibility-artifacts-attempt-2
-        name: Upload reproducibility artifacts (attempt 2)
-        if: steps.upload-reproducibility-artifacts-attempt-1.outcome == 'failure'
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: reproducibility-contract-${{ github.run_id }}
-          path: ${{ runner.temp }}/reproducibility
-          if-no-files-found: error
-
-      - name: Validate reproducibility artifact upload
-        if: always()
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $attempt1 = '${{ steps.upload-reproducibility-artifacts-attempt-1.outcome }}'
-          $attempt2 = '${{ steps.upload-reproducibility-artifacts-attempt-2.outcome }}'
-          if ($attempt1 -ne 'success' -and $attempt2 -ne 'success') {
-            throw 'Reproducibility artifact upload failed after two attempts.'
-          }
+          artifact_name: reproducibility-contract-${{ github.run_id }}
+          artifact_path: ${{ runner.temp }}/reproducibility
+          if_no_files_found: error
 
   provenance-contract:
     name: Provenance Contract
@@ -354,32 +317,13 @@ jobs:
             -OutputPath (Join-Path $provRoot 'provenance-contract-report.json')
           if ($LASTEXITCODE -ne 0) { throw 'Provenance contract validation failed.' }
 
-      - id: upload-provenance-artifacts-attempt-1
-        name: Upload provenance artifacts (attempt 1)
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
+      - id: upload-provenance-artifacts
+        name: Upload provenance artifacts
+        uses: ./.github/actions/upload-artifact-retry
         with:
-          name: provenance-contract-${{ github.run_id }}
-          path: ${{ runner.temp }}/provenance
-          if-no-files-found: error
+          artifact_name: provenance-contract-${{ github.run_id }}
+          artifact_path: ${{ runner.temp }}/provenance
+          if_no_files_found: error
 
-      - id: upload-provenance-artifacts-attempt-2
-        name: Upload provenance artifacts (attempt 2)
-        if: steps.upload-provenance-artifacts-attempt-1.outcome == 'failure'
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: provenance-contract-${{ github.run_id }}
-          path: ${{ runner.temp }}/provenance
-          if-no-files-found: error
 
-      - name: Validate provenance artifact upload
-        if: always()
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $attempt1 = '${{ steps.upload-provenance-artifacts-attempt-1.outcome }}'
-          $attempt2 = '${{ steps.upload-provenance-artifacts-attempt-2.outcome }}'
-          if ($attempt1 -ne 'success' -and $attempt2 -ne 'success') {
-            throw 'Provenance artifact upload failed after two attempts.'
-          }
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,121 @@
+{
+  "version": "2.0.0",
+  "inputs": [
+    {
+      "id": "opsRepo",
+      "type": "promptString",
+      "description": "GitHub repository slug",
+      "default": "svelderrainruiz/labview-cdev-surface"
+    },
+    {
+      "id": "opsWorkflow",
+      "type": "promptString",
+      "description": "Workflow file",
+      "default": "self-hosted-machine-certification.yml"
+    },
+    {
+      "id": "opsBranch",
+      "type": "promptString",
+      "description": "Branch",
+      "default": "main"
+    },
+    {
+      "id": "opsRunId",
+      "type": "promptString",
+      "description": "Run ID (optional for watch)"
+    }
+  ],
+  "tasks": [
+    {
+      "label": "ops: dispatch at remote head (portable)",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-File",
+        "scripts/Invoke-PortableOps.ps1",
+        "-ScriptPath",
+        "scripts/Dispatch-WorkflowAtRemoteHead.ps1",
+        "-ScriptArguments",
+        "-Repository",
+        "${input:opsRepo}",
+        "-WorkflowFile",
+        "${input:opsWorkflow}",
+        "-Branch",
+        "${input:opsBranch}",
+        "-CancelStale",
+        "-OutputPath",
+        "artifacts/dispatch/dispatch-report.json"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "ops: cancel stale runs (portable)",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-File",
+        "scripts/Invoke-PortableOps.ps1",
+        "-ScriptPath",
+        "scripts/Cancel-StaleWorkflowRuns.ps1",
+        "-ScriptArguments",
+        "-Repository",
+        "${input:opsRepo}",
+        "-WorkflowFile",
+        "${input:opsWorkflow}",
+        "-Branch",
+        "${input:opsBranch}",
+        "-OutputPath",
+        "artifacts/dispatch/cancel-report.json"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "ops: watch run (portable)",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-File",
+        "scripts/Invoke-PortableOps.ps1",
+        "-ScriptPath",
+        "scripts/Watch-WorkflowRun.ps1",
+        "-ScriptArguments",
+        "-Repository",
+        "${input:opsRepo}",
+        "-RunId",
+        "${input:opsRunId}",
+        "-WorkflowFile",
+        "${input:opsWorkflow}",
+        "-Branch",
+        "${input:opsBranch}",
+        "-OutputPath",
+        "artifacts/dispatch/watch-report.json"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "ops: runner queue snapshot (portable)",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-File",
+        "scripts/Invoke-PortableOps.ps1",
+        "-ScriptPath",
+        "scripts/Get-RunnerQueueSnapshot.ps1",
+        "-ScriptArguments",
+        "-Repository",
+        "${input:opsRepo}",
+        "-WorkflowFile",
+        "${input:opsWorkflow}",
+        "-Branch",
+        "${input:opsBranch}",
+        "-OutputPath",
+        "artifacts/dispatch/queue-snapshot.json"
+      ],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/scripts/Cancel-StaleWorkflowRuns.ps1
+++ b/scripts/Cancel-StaleWorkflowRuns.ps1
@@ -1,0 +1,82 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Repository,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkflowFile,
+
+    [Parameter()]
+    [string]$Branch = 'main',
+
+    [Parameter()]
+    [int]$KeepLatestN = 1,
+
+    [Parameter()]
+    [string]$TargetHeadSha = '',
+
+    [Parameter()]
+    [string]$OutputPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/WorkflowOps.Common.ps1')
+
+$allRuns = @(Invoke-GhJson -Arguments @(
+    'run', 'list',
+    '-R', $Repository,
+    '--workflow', $WorkflowFile,
+    '--branch', $Branch,
+    '--event', 'workflow_dispatch',
+    '--limit', '100',
+    '--json', 'databaseId,status,conclusion,url,createdAt,headSha'
+))
+
+$orderedRuns = @($allRuns | Sort-Object { Parse-RunTimestamp -Run $_ } -Descending)
+$keepIds = @($orderedRuns | Select-Object -First ([Math]::Max($KeepLatestN, 0)) | ForEach-Object { [string]$_.databaseId })
+$activeStatuses = @('queued', 'in_progress', 'requested', 'waiting', 'pending')
+
+$canceled = @()
+$skipped = @()
+foreach ($run in $orderedRuns) {
+    $runId = [string]$run.databaseId
+    $status = [string]$run.status
+    if ($activeStatuses -notcontains $status) {
+        continue
+    }
+
+    if ($keepIds -contains $runId) {
+        $skipped += [pscustomobject]@{ run_id = $runId; reason = 'keep_latest' }
+        continue
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($TargetHeadSha) -and [string]::Equals([string]$run.headSha, $TargetHeadSha, [System.StringComparison]::OrdinalIgnoreCase)) {
+        $skipped += [pscustomobject]@{ run_id = $runId; reason = 'target_head_sha' }
+        continue
+    }
+
+    Invoke-Gh -Arguments @('run', 'cancel', $runId, '-R', $Repository)
+    $canceled += [pscustomobject]@{
+        run_id = $runId
+        status = $status
+        head_sha = [string]$run.headSha
+        url = [string]$run.url
+    }
+}
+
+$report = [ordered]@{
+    timestamp_utc = Get-UtcNowIso
+    repository = $Repository
+    workflow = $WorkflowFile
+    branch = $Branch
+    keep_latest_n = $KeepLatestN
+    target_head_sha = $TargetHeadSha
+    total_runs_considered = @($orderedRuns).Count
+    canceled_runs = @($canceled)
+    skipped_runs = @($skipped)
+}
+
+Write-WorkflowOpsReport -Report $report -OutputPath $OutputPath

--- a/scripts/Dispatch-WorkflowAtRemoteHead.ps1
+++ b/scripts/Dispatch-WorkflowAtRemoteHead.ps1
@@ -1,0 +1,107 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Repository,
+
+    [Parameter(Mandatory = $true)]
+    [string]$WorkflowFile,
+
+    [Parameter()]
+    [string]$Branch = 'main',
+
+    [Parameter()]
+    [string[]]$Input = @(),
+
+    [Parameter()]
+    [switch]$CancelStale,
+
+    [Parameter()]
+    [int]$KeepLatestN = 1,
+
+    [Parameter()]
+    [int]$DispatchPauseSeconds = 4,
+
+    [Parameter()]
+    [string]$OutputPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/WorkflowOps.Common.ps1')
+
+$expectedHeadSha = (Invoke-GhText -Arguments @('api', "repos/$Repository/branches/$Branch", '--jq', '.commit.sha')).Trim()
+if ([string]::IsNullOrWhiteSpace($expectedHeadSha)) {
+    throw ("remote_head_sha_missing: unable to resolve remote head for '{0}:{1}'." -f $Repository, $Branch)
+}
+
+$cancelReport = $null
+if ($CancelStale) {
+    $cancelScript = Join-Path $PSScriptRoot 'Cancel-StaleWorkflowRuns.ps1'
+    $cancelJson = & pwsh -NoProfile -File $cancelScript `
+        -Repository $Repository `
+        -WorkflowFile $WorkflowFile `
+        -Branch $Branch `
+        -KeepLatestN $KeepLatestN `
+        -TargetHeadSha $expectedHeadSha
+    if ($LASTEXITCODE -ne 0) {
+        throw 'stale_run_cancellation_failed: unable to cancel stale runs before dispatch.'
+    }
+    $cancelReport = $cancelJson | ConvertFrom-Json -ErrorAction Stop
+}
+
+$dispatchStartedUtc = (Get-Date).ToUniversalTime()
+$dispatchArgs = @('workflow', 'run', $WorkflowFile, '-R', $Repository, '--ref', $Branch)
+$dispatchArgs += @(Convert-InputPairsToGhArgs -Input $Input)
+Invoke-Gh -Arguments $dispatchArgs
+
+Start-Sleep -Seconds $DispatchPauseSeconds
+
+$runList = @(Invoke-GhJson -Arguments @(
+    'run', 'list',
+    '-R', $Repository,
+    '--workflow', $WorkflowFile,
+    '--branch', $Branch,
+    '--event', 'workflow_dispatch',
+    '--limit', '30',
+    '--json', 'databaseId,status,conclusion,url,createdAt,headSha,displayTitle'
+))
+
+$candidates = @(
+    $runList | Where-Object {
+        $created = Parse-RunTimestamp -Run $_
+        $created.UtcDateTime -ge $dispatchStartedUtc.AddMinutes(-2)
+    } | Sort-Object { Parse-RunTimestamp -Run $_ } -Descending
+)
+
+$selectedRun = $candidates | Select-Object -First 1
+if ($null -eq $selectedRun) {
+    $selectedRun = @($runList | Sort-Object { Parse-RunTimestamp -Run $_ } -Descending | Select-Object -First 1)
+}
+if ($null -eq $selectedRun) {
+    throw 'dispatch_run_not_discovered: unable to discover dispatched workflow run.'
+}
+
+$runHeadSha = [string]$selectedRun.headSha
+if (-not [string]::Equals($runHeadSha, $expectedHeadSha, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw ("dispatch_head_sha_mismatch: expected {0} but dispatched run {1} resolved to {2}." -f $expectedHeadSha, [string]$selectedRun.databaseId, $runHeadSha)
+}
+
+$report = [ordered]@{
+    timestamp_utc = Get-UtcNowIso
+    repository = $Repository
+    workflow = $WorkflowFile
+    branch = $Branch
+    expected_head_sha = $expectedHeadSha
+    run_id = [string]$selectedRun.databaseId
+    head_sha = $runHeadSha
+    status = [string]$selectedRun.status
+    conclusion = [string]$selectedRun.conclusion
+    url = [string]$selectedRun.url
+    inputs = @($Input)
+    stale_cancel_report = $cancelReport
+}
+
+Write-WorkflowOpsReport -Report $report -OutputPath $OutputPath
+

--- a/scripts/Get-RunnerQueueSnapshot.ps1
+++ b/scripts/Get-RunnerQueueSnapshot.ps1
@@ -1,0 +1,75 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Repository,
+
+    [Parameter()]
+    [string]$WorkflowFile = '',
+
+    [Parameter()]
+    [string]$Branch = '',
+
+    [Parameter()]
+    [string]$OutputPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/WorkflowOps.Common.ps1')
+
+$runnerLines = Invoke-GhText -Arguments @('api', "repos/$Repository/actions/runners", '--paginate', '--jq', '.runners[] | @json')
+$runnerObjects = @()
+foreach ($line in @($runnerLines -split "`r?`n")) {
+    if ([string]::IsNullOrWhiteSpace([string]$line)) { continue }
+    $runnerObjects += @(([string]$line | ConvertFrom-Json -ErrorAction Stop))
+}
+
+$runArgs = @('run', 'list', '-R', $Repository, '--limit', '50', '--json', 'databaseId,status,conclusion,url,createdAt,headSha,workflowName')
+if (-not [string]::IsNullOrWhiteSpace($WorkflowFile)) {
+    $runArgs += @('--workflow', $WorkflowFile)
+}
+if (-not [string]::IsNullOrWhiteSpace($Branch)) {
+    $runArgs += @('--branch', $Branch)
+}
+$runObjects = @(Invoke-GhJson -Arguments $runArgs)
+
+$activeStatuses = @('queued', 'in_progress', 'requested', 'waiting', 'pending')
+$activeRuns = @($runObjects | Where-Object { $activeStatuses -contains [string]$_.status })
+
+$statusCounts = [ordered]@{}
+foreach ($status in @($runObjects | ForEach-Object { [string]$_.status } | Sort-Object -Unique)) {
+    if ([string]::IsNullOrWhiteSpace($status)) { continue }
+    $statusCounts[$status] = @($runObjects | Where-Object { [string]$_.status -eq $status }).Count
+}
+
+$report = [ordered]@{
+    timestamp_utc = Get-UtcNowIso
+    repository = $Repository
+    workflow = $WorkflowFile
+    branch = $Branch
+    runner_summary = [ordered]@{
+        total = @($runnerObjects).Count
+        online = @($runnerObjects | Where-Object { [string]$_.status -eq 'online' }).Count
+        busy = @($runnerObjects | Where-Object { [bool]$_.busy }).Count
+    }
+    run_summary = [ordered]@{
+        total = @($runObjects).Count
+        active = @($activeRuns).Count
+        status_counts = $statusCounts
+    }
+    active_runs = @($activeRuns | Sort-Object { Parse-RunTimestamp -Run $_ } -Descending | ForEach-Object {
+        [ordered]@{
+            run_id = [string]$_.databaseId
+            status = [string]$_.status
+            conclusion = [string]$_.conclusion
+            workflow = [string]$_.workflowName
+            head_sha = [string]$_.headSha
+            url = [string]$_.url
+            created_at = [string]$_.createdAt
+        }
+    })
+}
+
+Write-WorkflowOpsReport -Report $report -OutputPath $OutputPath

--- a/scripts/Invoke-PortableOps.ps1
+++ b/scripts/Invoke-PortableOps.ps1
@@ -1,0 +1,61 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+
+    [Parameter()]
+    [string[]]$ScriptArguments = @(),
+
+    [Parameter()]
+    [string]$Image = 'ghcr.io/svelderrainruiz/labview-cdev-surface-ops:v1',
+
+    [Parameter()]
+    [switch]$BuildLocalImage,
+
+    [Parameter()]
+    [string]$LocalTag = 'labview-cdev-surface-ops:local',
+
+    [Parameter()]
+    [switch]$HostFallback
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedScriptPath = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $ScriptPath))
+if (-not (Test-Path -LiteralPath $resolvedScriptPath -PathType Leaf)) {
+    throw "script_not_found: $resolvedScriptPath"
+}
+
+$dockerInfo = & docker info 2>$null
+$dockerReady = ($LASTEXITCODE -eq 0)
+if (-not $dockerReady -and $HostFallback) {
+    & pwsh -NoProfile -File $resolvedScriptPath @ScriptArguments
+    exit $LASTEXITCODE
+}
+if (-not $dockerReady) {
+    throw 'docker_not_ready: start Docker Desktop or use -HostFallback.'
+}
+
+if ($BuildLocalImage) {
+    & docker build -f (Join-Path $repoRoot 'tools/ops-runtime/Dockerfile') -t $LocalTag (Join-Path $repoRoot 'tools/ops-runtime')
+    if ($LASTEXITCODE -ne 0) {
+        throw 'docker_image_build_failed: unable to build local ops image.'
+    }
+    $Image = $LocalTag
+}
+
+$relativeScript = [System.IO.Path]::GetRelativePath($repoRoot, $resolvedScriptPath).Replace('\', '/')
+$containerScript = "/workspace/$relativeScript"
+$dockerArgs = @('run', '--rm', '-v', "${repoRoot}:/workspace", '-w', '/workspace')
+if (-not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
+    $dockerArgs += @('-e', "GH_TOKEN=$($env:GH_TOKEN)")
+}
+$dockerArgs += @($Image, 'pwsh', '-NoProfile', '-File', $containerScript)
+$dockerArgs += @($ScriptArguments)
+
+& docker @dockerArgs
+$exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+exit $exitCode

--- a/scripts/Watch-WorkflowRun.ps1
+++ b/scripts/Watch-WorkflowRun.ps1
@@ -1,0 +1,100 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Repository,
+
+    [Parameter()]
+    [string]$RunId = '',
+
+    [Parameter()]
+    [string]$WorkflowFile = '',
+
+    [Parameter()]
+    [string]$Branch = 'main',
+
+    [Parameter()]
+    [int]$TimeoutMinutes = 60,
+
+    [Parameter()]
+    [int]$PollSeconds = 20,
+
+    [Parameter()]
+    [string]$OutputPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/WorkflowOps.Common.ps1')
+
+if ([string]::IsNullOrWhiteSpace($RunId)) {
+    if ([string]::IsNullOrWhiteSpace($WorkflowFile)) {
+        throw 'run_id_or_workflow_required: provide -RunId or both -WorkflowFile and -Branch.'
+    }
+
+    $latest = @(Invoke-GhJson -Arguments @(
+        'run', 'list',
+        '-R', $Repository,
+        '--workflow', $WorkflowFile,
+        '--branch', $Branch,
+        '--limit', '1',
+        '--json', 'databaseId,url,status,conclusion,createdAt'
+    )) | Select-Object -First 1
+
+    if ($null -eq $latest) {
+        throw 'run_not_found: no workflow runs available to watch.'
+    }
+
+    $RunId = [string]$latest.databaseId
+}
+
+$deadline = (Get-Date).ToUniversalTime().AddMinutes([Math]::Max($TimeoutMinutes, 1))
+$lastState = $null
+while ($true) {
+    $run = Invoke-GhJson -Arguments @(
+        'run', 'view',
+        $RunId,
+        '-R', $Repository,
+        '--json', 'databaseId,status,conclusion,url,createdAt,updatedAt,headSha,workflowName,displayTitle'
+    )
+
+    $lastState = $run
+    if ([string]$run.status -eq 'completed') {
+        break
+    }
+
+    if ((Get-Date).ToUniversalTime() -ge $deadline) {
+        $report = [ordered]@{
+            timestamp_utc = Get-UtcNowIso
+            repository = $Repository
+            run_id = $RunId
+            status = [string]$run.status
+            conclusion = [string]$run.conclusion
+            url = [string]$run.url
+            timeout_minutes = $TimeoutMinutes
+            classified_reason = 'timeout'
+        }
+        Write-WorkflowOpsReport -Report $report -OutputPath $OutputPath
+        throw ("workflow_watch_timeout: run {0} did not complete within {1} minutes." -f $RunId, $TimeoutMinutes)
+    }
+
+    Start-Sleep -Seconds ([Math]::Max($PollSeconds, 5))
+}
+
+$classification = if ([string]$lastState.conclusion -eq 'success') { 'success' } else { 'non_success_conclusion' }
+$report = [ordered]@{
+    timestamp_utc = Get-UtcNowIso
+    repository = $Repository
+    run_id = $RunId
+    status = [string]$lastState.status
+    conclusion = [string]$lastState.conclusion
+    url = [string]$lastState.url
+    head_sha = [string]$lastState.headSha
+    classified_reason = $classification
+}
+
+Write-WorkflowOpsReport -Report $report -OutputPath $OutputPath
+if ($classification -ne 'success') {
+    throw ("workflow_run_failed: run {0} completed with conclusion '{1}'." -f $RunId, [string]$lastState.conclusion)
+}

--- a/scripts/lib/WorkflowOps.Common.ps1
+++ b/scripts/lib/WorkflowOps.Common.ps1
@@ -1,0 +1,115 @@
+#Requires -Version 7.0
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Gh {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    & gh @Arguments
+    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    if ($exitCode -ne 0) {
+        throw ("gh_command_failed: exit={0} command=gh {1}" -f $exitCode, ($Arguments -join ' '))
+    }
+}
+
+function Invoke-GhText {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $output = & gh @Arguments
+    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    if ($exitCode -ne 0) {
+        throw ("gh_command_failed: exit={0} command=gh {1}" -f $exitCode, ($Arguments -join ' '))
+    }
+
+    if ($output -is [System.Array]) {
+        return (($output | ForEach-Object { [string]$_ }) -join [Environment]::NewLine)
+    }
+
+    return [string]$output
+}
+
+function Invoke-GhJson {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $json = Invoke-GhText -Arguments $Arguments
+    if ([string]::IsNullOrWhiteSpace($json)) {
+        return $null
+    }
+
+    return ($json | ConvertFrom-Json -ErrorAction Stop)
+}
+
+function Ensure-ParentDirectory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    $parent = Split-Path -Path $fullPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+        New-Item -Path $parent -ItemType Directory -Force | Out-Null
+    }
+
+    return $fullPath
+}
+
+function Write-WorkflowOpsReport {
+    param(
+        [Parameter(Mandatory = $true)][object]$Report,
+        [Parameter()][string]$OutputPath = ''
+    )
+
+    $json = ($Report | ConvertTo-Json -Depth 10)
+    if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+        $resolvedPath = Ensure-ParentDirectory -Path $OutputPath
+        Set-Content -LiteralPath $resolvedPath -Value $json -Encoding utf8
+        Write-Host ("Report written: {0}" -f $resolvedPath)
+    }
+
+    Write-Output $json
+}
+
+function Get-UtcNowIso {
+    return (Get-Date).ToUniversalTime().ToString('o')
+}
+
+function Convert-InputPairsToGhArgs {
+    param([Parameter()][string[]]$Input = @())
+
+    $arguments = @()
+    foreach ($pair in @($Input)) {
+        $text = ([string]$pair).Trim()
+        if ([string]::IsNullOrWhiteSpace($text)) {
+            continue
+        }
+
+        $splitIndex = $text.IndexOf('=')
+        if ($splitIndex -lt 1) {
+            throw ("input_pair_invalid: '{0}' must be key=value." -f $text)
+        }
+
+        $key = $text.Substring(0, $splitIndex).Trim()
+        $value = $text.Substring($splitIndex + 1)
+        if ([string]::IsNullOrWhiteSpace($key)) {
+            throw ("input_key_invalid: '{0}' has empty key." -f $text)
+        }
+
+        $arguments += @('-f', ("{0}={1}" -f $key, $value))
+    }
+
+    return ,$arguments
+}
+
+function Parse-RunTimestamp {
+    param([Parameter(Mandatory = $true)][object]$Run)
+
+    $createdAt = [string]$Run.createdAt
+    if ([string]::IsNullOrWhiteSpace($createdAt)) {
+        return [DateTimeOffset]::MinValue
+    }
+
+    $value = [DateTimeOffset]::MinValue
+    if ([DateTimeOffset]::TryParse($createdAt, [ref]$value)) {
+        return $value
+    }
+
+    return [DateTimeOffset]::MinValue
+}

--- a/tests/CancelStaleWorkflowRunsContract.Tests.ps1
+++ b/tests/CancelStaleWorkflowRunsContract.Tests.ps1
@@ -1,0 +1,26 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Cancel stale workflow runs contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:path = Join-Path $script:repoRoot 'scripts/Cancel-StaleWorkflowRuns.ps1'
+        if (-not (Test-Path -LiteralPath $script:path -PathType Leaf)) {
+            throw "Script missing: $script:path"
+        }
+        $script:content = Get-Content -LiteralPath $script:path -Raw
+    }
+
+    It 'cancels only active stale runs' {
+        $script:content | Should -Match "'queued', 'in_progress', 'requested', 'waiting', 'pending'"
+        $script:content | Should -Match "'run', 'cancel'"
+    }
+
+    It 'supports keeping the latest runs and target head sha filtering' {
+        $script:content | Should -Match 'keep_latest_n'
+        $script:content | Should -Match 'target_head_sha'
+        $script:content | Should -Match 'target_head_sha'
+    }
+}

--- a/tests/CiWorkflowReliabilityContract.Tests.ps1
+++ b/tests/CiWorkflowReliabilityContract.Tests.ps1
@@ -20,27 +20,21 @@ Describe 'CI workflow reliability contract' {
         $script:workflowContent | Should -Match 'cancel-in-progress:\s*true'
     }
 
-    It 'uses two-attempt retry for workspace installer artifact uploads' {
-        $script:workflowContent | Should -Match 'id:\s*upload-workspace-installer-artifact-attempt-1'
-        $script:workflowContent | Should -Match 'id:\s*upload-workspace-installer-artifact-attempt-2'
-        $script:workflowContent | Should -Match 'if:\s*steps\.upload-workspace-installer-artifact-attempt-1\.outcome == ''failure'''
-        $script:workflowContent | Should -Match 'Validate workspace bootstrap installer artifact upload'
-        $script:workflowContent | Should -Match 'steps\.upload-workspace-installer-artifact-attempt-2\.outcome'
+    It 'uses reusable upload-artifact retry composite for workspace installer artifacts' {
+        $script:workflowContent | Should -Match 'id:\s*upload-workspace-installer-artifact'
+        $script:workflowContent | Should -Match 'uses:\s*\./\.github/actions/upload-artifact-retry'
+        $script:workflowContent | Should -Match 'artifact_name:\s*workspace-bootstrap-installer-\$\{\{\s*github\.run_id\s*\}\}'
     }
 
-    It 'uses two-attempt retry for reproducibility artifact uploads' {
-        $script:workflowContent | Should -Match 'id:\s*upload-reproducibility-artifacts-attempt-1'
-        $script:workflowContent | Should -Match 'id:\s*upload-reproducibility-artifacts-attempt-2'
-        $script:workflowContent | Should -Match 'if:\s*steps\.upload-reproducibility-artifacts-attempt-1\.outcome == ''failure'''
-        $script:workflowContent | Should -Match 'Validate reproducibility artifact upload'
-        $script:workflowContent | Should -Match 'steps\.upload-reproducibility-artifacts-attempt-2\.outcome'
+    It 'uses reusable upload-artifact retry composite for reproducibility artifacts' {
+        $script:workflowContent | Should -Match 'id:\s*upload-reproducibility-artifacts'
+        $script:workflowContent | Should -Match 'artifact_name:\s*reproducibility-contract-\$\{\{\s*github\.run_id\s*\}\}'
+        $script:workflowContent | Should -Match 'artifact_path:\s*\$\{\{\s*runner\.temp\s*\}\}/reproducibility'
     }
 
-    It 'uses two-attempt retry for provenance artifact uploads' {
-        $script:workflowContent | Should -Match 'id:\s*upload-provenance-artifacts-attempt-1'
-        $script:workflowContent | Should -Match 'id:\s*upload-provenance-artifacts-attempt-2'
-        $script:workflowContent | Should -Match 'if:\s*steps\.upload-provenance-artifacts-attempt-1\.outcome == ''failure'''
-        $script:workflowContent | Should -Match 'Validate provenance artifact upload'
-        $script:workflowContent | Should -Match 'steps\.upload-provenance-artifacts-attempt-2\.outcome'
+    It 'uses reusable upload-artifact retry composite for provenance artifacts' {
+        $script:workflowContent | Should -Match 'id:\s*upload-provenance-artifacts'
+        $script:workflowContent | Should -Match 'artifact_name:\s*provenance-contract-\$\{\{\s*github\.run_id\s*\}\}'
+        $script:workflowContent | Should -Match 'artifact_path:\s*\$\{\{\s*runner\.temp\s*\}\}/provenance'
     }
 }

--- a/tests/DispatchWorkflowAtRemoteHeadContract.Tests.ps1
+++ b/tests/DispatchWorkflowAtRemoteHeadContract.Tests.ps1
@@ -1,0 +1,32 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Dispatch workflow at remote head contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:path = Join-Path $script:repoRoot 'scripts/Dispatch-WorkflowAtRemoteHead.ps1'
+        if (-not (Test-Path -LiteralPath $script:path -PathType Leaf)) {
+            throw "Script missing: $script:path"
+        }
+        $script:content = Get-Content -LiteralPath $script:path -Raw
+    }
+
+    It 'verifies run head SHA against remote branch head' {
+        $script:content | Should -Match 'expectedHeadSha'
+        $script:content | Should -Match 'dispatch_head_sha_mismatch'
+    }
+
+    It 'supports stale-run cancellation before dispatch' {
+        $script:content | Should -Match 'Cancel-StaleWorkflowRuns\.ps1'
+        $script:content | Should -Match '-TargetHeadSha \$expectedHeadSha'
+    }
+
+    It 'emits deterministic dispatch report fields' {
+        $script:content | Should -Match 'timestamp_utc'
+        $script:content | Should -Match 'repository = \$Repository'
+        $script:content | Should -Match 'workflow = \$WorkflowFile'
+        $script:content | Should -Match 'branch = \$Branch'
+    }
+}

--- a/tests/MachineCertificationProfilesContract.Tests.ps1
+++ b/tests/MachineCertificationProfilesContract.Tests.ps1
@@ -79,4 +79,11 @@ Describe 'Machine certification setup profile contract' {
             [bool]$setup.require_secondary_32 | Should -Be $false
         }
     }
+    It 'includes 2025 and 2026 host setup entries for actor-routed dispatch' {
+        $names = @($script:activeSetups | ForEach-Object { [string]$_.name })
+        $names | Should -Contain 'host-2025-desktop-windows'
+        $names | Should -Contain 'host-2026-desktop-linux'
+        $names | Should -Contain 'host-2026-desktop-windows'
+    }
 }
+

--- a/tests/PortableOpsRuntimeContract.Tests.ps1
+++ b/tests/PortableOpsRuntimeContract.Tests.ps1
@@ -1,0 +1,32 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Portable ops runtime contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:dockerfile = Join-Path $script:repoRoot 'tools/ops-runtime/Dockerfile'
+        $script:wrapper = Join-Path $script:repoRoot 'scripts/Invoke-PortableOps.ps1'
+        if (-not (Test-Path -LiteralPath $script:dockerfile -PathType Leaf)) {
+            throw "Dockerfile missing: $script:dockerfile"
+        }
+        if (-not (Test-Path -LiteralPath $script:wrapper -PathType Leaf)) {
+            throw "Wrapper missing: $script:wrapper"
+        }
+        $script:dockerContent = Get-Content -LiteralPath $script:dockerfile -Raw
+        $script:wrapperContent = Get-Content -LiteralPath $script:wrapper -Raw
+    }
+
+    It 'pins a PowerShell-based container runtime with git gh jq' {
+        $script:dockerContent | Should -Match 'mcr\.microsoft\.com/powershell'
+        $script:dockerContent | Should -Match 'git jq gh'
+    }
+
+    It 'mounts workspace and forwards GH_TOKEN to containerized ops scripts' {
+        $script:wrapperContent | Should -Match "'-v'"
+        $script:wrapperContent | Should -Match '/workspace'
+        $script:wrapperContent | Should -Match 'GH_TOKEN='
+        $script:wrapperContent | Should -Match 'docker_not_ready'
+    }
+}

--- a/tests/StartSelfHostedMachineCertificationContract.Tests.ps1
+++ b/tests/StartSelfHostedMachineCertificationContract.Tests.ps1
@@ -30,4 +30,12 @@ Describe 'Start self-hosted machine certification dispatch contract' {
         $script:startScriptContent | Should -Match 'execution_bitness = \$executionBitness'
         $script:startScriptContent | Should -Match 'require_secondary_32 = \$requireSecondary32'
     }
+    It 'auto-attaches missing upstream actor labels when base routing matches' {
+        $script:startScriptContent | Should -Match 'function Get-RunnerInventory'
+        $script:startScriptContent | Should -Match 'requiredActorLabels = @\(\$requiredLabels \| Where-Object \{ \$_ -like ''cert-actor-\*'' \}'
+        $script:startScriptContent | Should -Match 'runner_actor_label_autofix'
+        $script:startScriptContent | Should -Match 'actions/runners/\{0\}/labels'
+        $script:startScriptContent | Should -Match 'labels\[\]='
+    }
 }
+

--- a/tests/UploadArtifactRetryCompositeContract.Tests.ps1
+++ b/tests/UploadArtifactRetryCompositeContract.Tests.ps1
@@ -1,0 +1,22 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Upload artifact retry composite contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:path = Join-Path $script:repoRoot '.github/actions/upload-artifact-retry/action.yml'
+        if (-not (Test-Path -LiteralPath $script:path -PathType Leaf)) {
+            throw "Composite missing: $script:path"
+        }
+        $script:content = Get-Content -LiteralPath $script:path -Raw
+    }
+
+    It 'attempts upload twice and fails after both attempts fail' {
+        $script:content | Should -Match 'upload_attempt_1'
+        $script:content | Should -Match 'upload_attempt_2'
+        $script:content | Should -Match "if: steps\.upload_attempt_1\.outcome == 'failure'"
+        $script:content | Should -Match 'artifact_upload_failed_after_two_attempts'
+    }
+}

--- a/tests/VsCodeTasksContract.Tests.ps1
+++ b/tests/VsCodeTasksContract.Tests.ps1
@@ -1,0 +1,32 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'VS Code tasks contract for portable workflow ops' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:tasksPath = Join-Path $script:repoRoot '.vscode/tasks.json'
+        if (-not (Test-Path -LiteralPath $script:tasksPath -PathType Leaf)) {
+            throw "Tasks missing: $script:tasksPath"
+        }
+        $script:tasksDoc = Get-Content -LiteralPath $script:tasksPath -Raw | ConvertFrom-Json -ErrorAction Stop
+        $script:labels = @($script:tasksDoc.tasks | ForEach-Object { [string]$_.label })
+    }
+
+    It 'defines dispatch/cancel/watch/queue portable tasks' {
+        $script:labels | Should -Contain 'ops: dispatch at remote head (portable)'
+        $script:labels | Should -Contain 'ops: cancel stale runs (portable)'
+        $script:labels | Should -Contain 'ops: watch run (portable)'
+        $script:labels | Should -Contain 'ops: runner queue snapshot (portable)'
+    }
+
+    It 'routes tasks through Invoke-PortableOps wrapper' {
+        $raw = Get-Content -LiteralPath $script:tasksPath -Raw
+        $raw | Should -Match 'Invoke-PortableOps\.ps1'
+        $raw | Should -Match 'Dispatch-WorkflowAtRemoteHead\.ps1'
+        $raw | Should -Match 'Cancel-StaleWorkflowRuns\.ps1'
+        $raw | Should -Match 'Watch-WorkflowRun\.ps1'
+        $raw | Should -Match 'Get-RunnerQueueSnapshot\.ps1'
+    }
+}

--- a/tests/WatchWorkflowRunContract.Tests.ps1
+++ b/tests/WatchWorkflowRunContract.Tests.ps1
@@ -1,0 +1,21 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Watch workflow run contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:path = Join-Path $script:repoRoot 'scripts/Watch-WorkflowRun.ps1'
+        if (-not (Test-Path -LiteralPath $script:path -PathType Leaf)) {
+            throw "Script missing: $script:path"
+        }
+        $script:content = Get-Content -LiteralPath $script:path -Raw
+    }
+
+    It 'classifies timeout and non-success conclusions deterministically' {
+        $script:content | Should -Match 'workflow_watch_timeout'
+        $script:content | Should -Match 'workflow_run_failed'
+        $script:content | Should -Match 'classified_reason'
+    }
+}

--- a/tools/machine-certification/setup-profiles.json
+++ b/tools/machine-certification/setup-profiles.json
@@ -43,6 +43,26 @@
       "require_secondary_32": true
     },
     {
+      "name": "host-2025-desktop-windows",
+      "description": "Windows self-hosted runner with LabVIEW 2025 x64 host path checks and Docker desktop-windows context.",
+      "setup_route_label": "cert-setup-host-2025-desktop-windows",
+      "allowed_machine_names": [
+        "GHOST"
+      ],
+      "runner_labels_csv": "self-hosted,windows,self-hosted-windows-lv,headless",
+      "collision_guard_label": "cdev-surface-windows-gate",
+      "runner_labels_json": "[\"self-hosted\",\"windows\",\"self-hosted-windows-lv\",\"headless\"]",
+      "expected_labview_year": "2025",
+      "docker_context": "desktop-windows",
+      "start_docker_desktop_if_needed": true,
+      "switch_docker_context": true,
+      "skip_host_ini_mutation": true,
+      "skip_override_phase": false,
+      "active": true,
+      "execution_bitness": "64",
+      "require_secondary_32": false
+    },
+    {
       "name": "host-2026-desktop-linux",
       "description": "Windows self-hosted runner with LabVIEW 2026 x86/x64 host path checks and Docker desktop-linux context.",
       "setup_route_label": "cert-setup-host-2026-desktop-linux",

--- a/tools/ops-runtime/Dockerfile
+++ b/tools/ops-runtime/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/powershell:7.4-ubuntu-22.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git jq gh ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Introduce reusable CI platform primitives:
  - Composite action: .github/actions/upload-artifact-retry
  - Shared workflow-ops library: scripts/lib/WorkflowOps.Common.ps1
  - New ops scripts:
    - scripts/Dispatch-WorkflowAtRemoteHead.ps1
    - scripts/Cancel-StaleWorkflowRuns.ps1
    - scripts/Watch-WorkflowRun.ps1
    - scripts/Get-RunnerQueueSnapshot.ps1
    - scripts/Invoke-PortableOps.ps1
  - Portable ops runtime image scaffold: 	ools/ops-runtime/Dockerfile
  - VS Code portable task wrappers: .vscode/tasks.json
- Reduce CI duplication by migrating ci.yml artifact uploads to the composite action.
- Propagate upstream actor-label resilience in Start-SelfHostedMachineCertification.ps1:
  - auto-attach missing cert-actor-* labels on upstream runners when base route labels already match.
- Extend setup profiles with host-2025-desktop-windows.

## Behavior parity
- Existing two-attempt artifact upload semantics preserved; now centralized in one composite action.
- Dispatch still fail-closed when no eligible route exists.
- Actor-label autofix applies only for upstream owner (LabVIEW-Community-CI-CD) and only when base route labels are already satisfiable.

## Validation
- Invoke-Pester (36 tests) passed locally, including:
  - updated CI reliability contracts
  - new ops/tooling contracts
  - updated machine certification/actor-label contracts