### PR TITLE
feat: topology readiness gate + fork main auto-sync workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,29 @@ jobs:
       - id: topology_scope
         name: Resolve topology readiness scope
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
           $requireNotBehind = $false
-          $pinManifestPaths = @(
-            'workspace-governance.json',
-            'workspace-governance-payload/workspace-governance/workspace-governance.json'
-          )
 
           if ('${{ github.event_name }}' -eq 'pull_request') {
-            git fetch origin "${{ github.base_ref }}" --depth=1
-            $diff = git diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- $pinManifestPaths
-            if ($diff -match '(?m)^[\+\-].*"pinned_sha"\s*:') {
+            $repoSlug = '${{ github.repository }}'
+            $prNumber = '${{ github.event.pull_request.number }}'
+            $pinPatch = & gh api "repos/$repoSlug/pulls/$prNumber/files" `
+              --paginate `
+              --jq '.[] | select(.filename=="workspace-governance.json" or .filename=="workspace-governance-payload/workspace-governance/workspace-governance.json") | (.patch // "")'
+            if ($LASTEXITCODE -ne 0) {
+              throw 'topology_scope_pr_files_query_failed'
+            }
+
+            $patchText = if ($pinPatch -is [System.Array]) {
+              ($pinPatch | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+            } else {
+              [string]$pinPatch
+            }
+
+            if ($patchText -match '(?m)^[\+\-].*"pinned_sha"\s*:') {
               $requireNotBehind = $true
             }
           }
@@ -75,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: topology-readiness-${{ github.run_id }}
-          path: ${{ steps.topology_readiness.outputs.report_path }}
+          path: ${{ runner.temp }}/topology-readiness-report.json
           if-no-files-found: warn
       - name: Install Pester
         shell: pwsh
@@ -381,4 +392,5 @@ jobs:
           artifact_name: provenance-contract-${{ github.run_id }}
           artifact_path: ${{ runner.temp }}/provenance
           if_no_files_found: error
+
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,61 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - id: topology_scope
+        name: Resolve topology readiness scope
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $requireNotBehind = $false
+          $pinManifestPaths = @(
+            'workspace-governance.json',
+            'workspace-governance-payload/workspace-governance/workspace-governance.json'
+          )
+
+          if ('${{ github.event_name }}' -eq 'pull_request') {
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            $diff = git diff --unified=0 "origin/${{ github.base_ref }}...HEAD" -- $pinManifestPaths
+            if ($diff -match '(?m)^[\+\-].*"pinned_sha"\s*:') {
+              $requireNotBehind = $true
+            }
+          }
+
+          "require_not_behind=$([string]$requireNotBehind)".ToLowerInvariant() | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - id: topology_readiness
+        name: Assert topology readiness (fail-closed for pin PRs)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $reportPath = Join-Path $env:RUNNER_TEMP 'topology-readiness-report.json'
+          "report_path=$reportPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          $args = @(
+            '-NoProfile',
+            '-File', './scripts/Assert-TopologyReadiness.ps1',
+            '-ForkRepository', 'svelderrainruiz/labview-cdev-surface',
+            '-UpstreamRepository', 'LabVIEW-Community-CI-CD/labview-cdev-surface',
+            '-Branch', 'main',
+            '-OutputPath', $reportPath
+          )
+          if ('${{ steps.topology_scope.outputs.require_not_behind }}' -eq 'true') {
+            $args += '-RequireNotBehind'
+          }
+
+          & pwsh @args
+          if ($LASTEXITCODE -ne 0) {
+            throw "topology_readiness_failed: Assert-TopologyReadiness.ps1 exited with code $LASTEXITCODE."
+          }
+
+      - name: Upload topology readiness report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: topology-readiness-${{ github.run_id }}
+          path: ${{ steps.topology_readiness.outputs.report_path }}
+          if-no-files-found: warn
       - name: Install Pester
         shell: pwsh
         run: |
@@ -56,6 +111,8 @@ jobs:
             './tests/MachineCertificationProfilesContract.Tests.ps1',
             './tests/StartSelfHostedMachineCertificationContract.Tests.ps1',
             './tests/DispatchWorkflowAtRemoteHeadContract.Tests.ps1',
+            './tests/TopologyReadinessScriptContract.Tests.ps1',
+            './tests/SyncForkMainWithUpstreamWorkflowContract.Tests.ps1',
             './tests/CancelStaleWorkflowRunsContract.Tests.ps1',
             './tests/WatchWorkflowRunContract.Tests.ps1',
             './tests/PortableOpsRuntimeContract.Tests.ps1',
@@ -324,6 +381,4 @@ jobs:
           artifact_name: provenance-contract-${{ github.run_id }}
           artifact_path: ${{ runner.temp }}/provenance
           if_no_files_found: error
-
-
 

--- a/.github/workflows/sync-fork-main-with-upstream.yml
+++ b/.github/workflows/sync-fork-main-with-upstream.yml
@@ -1,0 +1,123 @@
+name: Sync Fork Main With Upstream
+
+on:
+  schedule:
+    - cron: '15 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-fork-main-with-upstream:
+    name: Sync Fork Main With Upstream
+    if: ${{ github.repository == 'svelderrainruiz/labview-cdev-surface' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: sync-fork-main-with-upstream
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git author
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - id: topology
+        name: Compare fork main against upstream main
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $compare = & gh api repos/LabVIEW-Community-CI-CD/labview-cdev-surface/compare/main...svelderrainruiz:main | ConvertFrom-Json -ErrorAction Stop
+          $behindBy = [int]$compare.behind_by
+          $aheadBy = [int]$compare.ahead_by
+          $upstreamHead = [string]$compare.base_commit.sha
+          $forkHead = [string]$compare.merge_base_commit.sha
+          if ($null -ne $compare.PSObject.Properties['commits'] -and @($compare.commits).Count -gt 0) {
+            $forkHead = [string]@($compare.commits)[-1].sha
+          }
+
+          $syncBranch = "sync/fork-main-with-upstream-$($upstreamHead.Substring(0,7))"
+          "behind_by=$behindBy" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "ahead_by=$aheadBy" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "upstream_head=$upstreamHead" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "fork_head=$forkHead" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "sync_branch=$syncBranch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - id: existing_pr
+        if: steps.topology.outputs.behind_by != '0'
+        name: Detect existing sync PR
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $head = "svelderrainruiz:${{ steps.topology.outputs.sync_branch }}"
+          $prNumber = (& gh pr list -R svelderrainruiz/labview-cdev-surface --state open --head $head --base main --json number --jq '.[0].number').Trim()
+          if ([string]::IsNullOrWhiteSpace($prNumber)) {
+            $prNumber = ''
+          }
+          "number=$prNumber" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Create no-force sync branch
+        if: steps.topology.outputs.behind_by != '0' && steps.existing_pr.outputs.number == ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          git remote add upstream https://github.com/LabVIEW-Community-CI-CD/labview-cdev-surface.git
+          git fetch upstream main --no-tags
+          git fetch origin main --no-tags
+          git checkout -B "${{ steps.topology.outputs.sync_branch }}" origin/main
+          git merge --no-ff --no-edit upstream/main
+          git push --set-upstream origin "${{ steps.topology.outputs.sync_branch }}"
+
+      - name: Open sync PR
+        if: steps.topology.outputs.behind_by != '0' && steps.existing_pr.outputs.number == ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $body = @"
+          Automated no-force synchronization of fork `main` with `upstream/main`.
+
+          - behind_by (pre-merge): `${{ steps.topology.outputs.behind_by }}`
+          - ahead_by (pre-merge): `${{ steps.topology.outputs.ahead_by }}`
+          - upstream head: `${{ steps.topology.outputs.upstream_head }}`
+          - run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          "@
+
+          & gh pr create `
+            -R svelderrainruiz/labview-cdev-surface `
+            --base main `
+            --head "${{ steps.topology.outputs.sync_branch }}" `
+            --title "chore(sync): align fork main with upstream main" `
+            --body $body
+          if ($LASTEXITCODE -ne 0) {
+            throw 'sync_pr_create_failed'
+          }
+
+      - name: Summarize
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $summary = @(
+            "## Sync Fork Main With Upstream",
+            "",
+            "- behind_by: `${{ steps.topology.outputs.behind_by }}`",
+            "- ahead_by: `${{ steps.topology.outputs.ahead_by }}`",
+            "- upstream_head: `${{ steps.topology.outputs.upstream_head }}`",
+            "- sync_branch: `${{ steps.topology.outputs.sync_branch }}`",
+            "- existing_pr: `${{ steps.existing_pr.outputs.number }}`"
+          ) -join [Environment]::NewLine
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Build and gate lanes must run in isolated workspaces on every run (`D:\dev` pref
 - On drift, automation must update manifest pins, create/update branch `automation/sha-refresh`, and open or update a PR to `main`.
 - `workspace-sha-drift-signal.yml` uses `WORKFLOW_BOT_TOKEN` for cross-repo default-branch SHA reads.
 - `workspace-sha-refresh-pr.yml` requires repository secret `WORKFLOW_BOT_TOKEN` for branch mutation and PR operations.
+- `CI Pipeline` enforces topology readiness for pin-change PRs through `scripts/Assert-TopologyReadiness.ps1` (fail-closed when fork `main` is behind upstream `main`).
+- `.github/workflows/sync-fork-main-with-upstream.yml` provides scheduled no-force fork-main sync PR generation.
 - Refresh CI propagation is PR-event-driven; do not explicitly dispatch `ci.yml` from refresh automation.
 - If `WORKFLOW_BOT_TOKEN` is missing or misconfigured, refresh automation must fail fast with explicit remediation.
 - Auto-merge is enabled by default for refresh PRs using squash strategy.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The NSIS payload bundles pinned CLI assets for both `win-x64` and `linux-x64` an
 
 `Workspace SHA Refresh PR` is the default remediation workflow. It updates `pinned_sha` values, reuses branch `automation/sha-refresh`, and creates or updates a single refresh PR to `main`.
 
+Topology readiness policy: pin-change PRs fail closed when `fork/main` is behind `upstream/main` (enforced by `scripts/Assert-TopologyReadiness.ps1` in `CI Pipeline`).
+No-force sync policy: `.github/workflows/sync-fork-main-with-upstream.yml` opens a fork PR that merges `upstream/main` into fork `main` before pinning lanes proceed.
+
 Auto-refresh policy:
 1. Auto-merge is enabled by default for refresh PRs with squash strategy.
 2. Maintainer approval is not required for `labview-cdev-surface` refresh merges (`required_approving_review_count = 0`).

--- a/scripts/Assert-TopologyReadiness.ps1
+++ b/scripts/Assert-TopologyReadiness.ps1
@@ -1,0 +1,96 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ForkRepository = 'svelderrainruiz/labview-cdev-surface',
+
+    [Parameter()]
+    [string]$UpstreamRepository = 'LabVIEW-Community-CI-CD/labview-cdev-surface',
+
+    [Parameter()]
+    [string]$Branch = 'main',
+
+    [Parameter()]
+    [switch]$RequireNotBehind,
+
+    [Parameter()]
+    [string]$OutputPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'lib/WorkflowOps.Common.ps1')
+
+function Split-RepositorySlug {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repository
+    )
+
+    $parts = $Repository.Split('/', 2)
+    if ($parts.Count -ne 2 -or [string]::IsNullOrWhiteSpace($parts[0]) -or [string]::IsNullOrWhiteSpace($parts[1])) {
+        throw ("repository_slug_invalid: '{0}' must use owner/name format." -f $Repository)
+    }
+
+    return @($parts[0], $parts[1])
+}
+
+$forkParts = Split-RepositorySlug -Repository $ForkRepository
+$upstreamParts = Split-RepositorySlug -Repository $UpstreamRepository
+$forkOwner = $forkParts[0]
+$forkRepoName = $forkParts[1]
+$upstreamRepoName = $upstreamParts[1]
+
+if (-not [string]::Equals($forkRepoName, $upstreamRepoName, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw ("repository_name_mismatch: fork '{0}' and upstream '{1}' must reference the same repository name." -f $ForkRepository, $UpstreamRepository)
+}
+
+$compareRef = "{0}...{1}:{0}" -f $Branch, $forkOwner
+$compareEndpoint = "repos/{0}/compare/{1}" -f $UpstreamRepository, $compareRef
+$compare = Invoke-GhJson -Arguments @('api', $compareEndpoint)
+if ($null -eq $compare) {
+    throw ("compare_response_empty: unable to resolve topology comparison for '{0}'." -f $compareEndpoint)
+}
+
+$aheadBy = [int]$compare.ahead_by
+$behindBy = [int]$compare.behind_by
+$status = [string]$compare.status
+
+$classification = if ($RequireNotBehind) { 'require_not_behind' } else { 'audit_only' }
+$pass = $true
+if ($RequireNotBehind -and $behindBy -gt 0) {
+    $pass = $false
+}
+
+$headSha = ''
+$compareCommits = @($compare.commits)
+if ($compareCommits.Count -gt 0) {
+    $headSha = [string]$compareCommits[-1].sha
+} elseif ($null -ne $compare.PSObject.Properties['merge_base_commit']) {
+    $headSha = [string]$compare.merge_base_commit.sha
+}
+
+$report = [ordered]@{
+    timestamp_utc = Get-UtcNowIso
+    fork_repository = $ForkRepository
+    upstream_repository = $UpstreamRepository
+    branch = $Branch
+    compare_endpoint = $compareEndpoint
+    compare_url = [string]$compare.html_url
+    status = $status
+    ahead_by = $aheadBy
+    behind_by = $behindBy
+    require_not_behind = [bool]$RequireNotBehind
+    pass = $pass
+    classification = $classification
+    base_sha = [string]$compare.base_commit.sha
+    merge_base_sha = [string]$compare.merge_base_commit.sha
+    head_sha = $headSha
+}
+
+Write-WorkflowOpsReport -Report $report -OutputPath $OutputPath
+
+if (-not $pass) {
+    throw ("topology_not_ready: fork repository '{0}' is behind upstream '{1}' on branch '{2}' by {3} commit(s). Sync fork main with upstream main before pinning changes." -f $ForkRepository, $UpstreamRepository, $Branch, $behindBy)
+}

--- a/tests/CiWorkflowReliabilityContract.Tests.ps1
+++ b/tests/CiWorkflowReliabilityContract.Tests.ps1
@@ -20,6 +20,15 @@ Describe 'CI workflow reliability contract' {
         $script:workflowContent | Should -Match 'cancel-in-progress:\s*true'
     }
 
+    It 'fails closed on pin-change PRs when fork topology is behind upstream' {
+        $script:workflowContent | Should -Match 'id:\s*topology_scope'
+        $script:workflowContent | Should -Match 'id:\s*topology_readiness'
+        $script:workflowContent | Should -Match 'Assert-TopologyReadiness\.ps1'
+        $script:workflowContent | Should -Match 'steps\.topology_scope\.outputs\.require_not_behind'
+        $script:workflowContent | Should -Match 'topology_readiness_failed'
+        $script:workflowContent | Should -Match 'topology-readiness-\$\{\{\s*github\.run_id\s*\}\}'
+    }
+
     It 'uses reusable upload-artifact retry composite for workspace installer artifacts' {
         $script:workflowContent | Should -Match 'id:\s*upload-workspace-installer-artifact'
         $script:workflowContent | Should -Match 'uses:\s*\./\.github/actions/upload-artifact-retry'

--- a/tests/SyncForkMainWithUpstreamWorkflowContract.Tests.ps1
+++ b/tests/SyncForkMainWithUpstreamWorkflowContract.Tests.ps1
@@ -1,0 +1,37 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Sync fork main with upstream workflow contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:workflowPath = Join-Path $script:repoRoot '.github/workflows/sync-fork-main-with-upstream.yml'
+        if (-not (Test-Path -LiteralPath $script:workflowPath -PathType Leaf)) {
+            throw "Workflow missing: $script:workflowPath"
+        }
+
+        $script:workflowContent = Get-Content -LiteralPath $script:workflowPath -Raw
+    }
+
+    It 'is schedule and dispatch driven with write permissions for PR sync automation' {
+        $script:workflowContent | Should -Match 'schedule:'
+        $script:workflowContent | Should -Match 'workflow_dispatch:'
+        $script:workflowContent | Should -Match 'contents:\s*write'
+        $script:workflowContent | Should -Match 'pull-requests:\s*write'
+    }
+
+    It 'runs only in fork repo and computes topology via compare API' {
+        $script:workflowContent | Should -Match "github\.repository == 'svelderrainruiz/labview-cdev-surface'"
+        $script:workflowContent | Should -Match 'compare/main\.\.\.svelderrainruiz:main'
+        $script:workflowContent | Should -Match 'behind_by'
+        $script:workflowContent | Should -Match 'sync/fork-main-with-upstream-'
+    }
+
+    It 'uses no-force merge and PR flow to sync fork main' {
+        $script:workflowContent | Should -Match 'git merge --no-ff --no-edit upstream/main'
+        $script:workflowContent | Should -Match 'git push --set-upstream origin'
+        $script:workflowContent | Should -Match 'gh pr create'
+        $script:workflowContent | Should -Match '--base main'
+    }
+}

--- a/tests/TopologyReadinessScriptContract.Tests.ps1
+++ b/tests/TopologyReadinessScriptContract.Tests.ps1
@@ -1,0 +1,37 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Topology readiness script contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:scriptPath = Join-Path $script:repoRoot 'scripts/Assert-TopologyReadiness.ps1'
+        if (-not (Test-Path -LiteralPath $script:scriptPath -PathType Leaf)) {
+            throw "Topology script missing: $script:scriptPath"
+        }
+
+        $script:scriptContent = Get-Content -LiteralPath $script:scriptPath -Raw
+    }
+
+    It 'compares upstream and fork branch topology using GitHub compare API' {
+        $script:scriptContent | Should -Match 'repos/\{0\}/compare/\{1\}'
+        $script:scriptContent | Should -Match '\{0\}\.\.\.\{1\}:\{0\}'
+        $script:scriptContent | Should -Match 'ahead_by'
+        $script:scriptContent | Should -Match 'behind_by'
+    }
+
+    It 'fails closed when required not-behind contract is violated' {
+        $script:scriptContent | Should -Match 'RequireNotBehind'
+        $script:scriptContent | Should -Match 'classification = if \(\$RequireNotBehind\) \{ ''require_not_behind'' \} else \{ ''audit_only'' \}'
+        $script:scriptContent | Should -Match 'topology_not_ready'
+    }
+
+    It 'emits deterministic report fields for gating evidence' {
+        $script:scriptContent | Should -Match 'timestamp_utc'
+        $script:scriptContent | Should -Match 'fork_repository'
+        $script:scriptContent | Should -Match 'upstream_repository'
+        $script:scriptContent | Should -Match 'require_not_behind'
+        $script:scriptContent | Should -Match 'pass = \$pass'
+    }
+}


### PR DESCRIPTION
## Summary
Implements the first slice of the fork-first topology model from issue #51.

### Included
- Adds `scripts/Assert-TopologyReadiness.ps1` to compare fork/upstream branch topology and fail closed when `-RequireNotBehind` is set.
- Wires `CI Pipeline` to enforce topology readiness for pin-change PRs (audit-only for non-pin PRs).
- Adds scheduled no-force sync workflow: `.github/workflows/sync-fork-main-with-upstream.yml`.
- Adds contract coverage:
  - `tests/TopologyReadinessScriptContract.Tests.ps1`
  - `tests/SyncForkMainWithUpstreamWorkflowContract.Tests.ps1`
  - extended `tests/CiWorkflowReliabilityContract.Tests.ps1`
- Documents policy in `AGENTS.md` and `README.md`.

## Validation
- `Invoke-Pester` on:
  - `tests/WorkspaceSurfaceContract.Tests.ps1`
  - `tests/CiWorkflowReliabilityContract.Tests.ps1`
  - `tests/TopologyReadinessScriptContract.Tests.ps1`
  - `tests/SyncForkMainWithUpstreamWorkflowContract.Tests.ps1`

## Link
- Closes #51