### PR TITLE
chore(manifest): refresh pinned SHAs

### DIFF
--- a/workspace-governance-payload/workspace-governance/workspace-governance.json
+++ b/workspace-governance-payload/workspace-governance/workspace-governance.json
@@ -301,7 +301,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "831274953534adf0d69f6dcb3a4eaeae990fb3b0"
+      "pinned_sha": "fda45ac448d4b3dcf498bac291681b1dc3bc449d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -466,7 +466,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "0fba6c8a972d00137c6410a9c4df49fabb452ee2"
+      "pinned_sha": "ae926b380fc8aa347de0949c0736fde613fb00a8"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -499,7 +499,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "ab8960d2e8e04cf91c684e2e5b2471f53ca5bb19"
+      "pinned_sha": "a5962debed4f94ca19ecf8ed87346b35568c0d64"
     }
   ]
 }

--- a/workspace-governance.json
+++ b/workspace-governance.json
@@ -301,7 +301,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "831274953534adf0d69f6dcb3a4eaeae990fb3b0"
+      "pinned_sha": "fda45ac448d4b3dcf498bac291681b1dc3bc449d"
     },
     {
       "path": "C:\\dev\\labview-for-containers",
@@ -466,7 +466,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "0fba6c8a972d00137c6410a9c4df49fabb452ee2"
+      "pinned_sha": "ae926b380fc8aa347de0949c0736fde613fb00a8"
     },
     {
       "path": "C:\\dev\\labview-cdev-surface-upstream",
@@ -499,7 +499,7 @@
       },
       "forbid_force_push": true,
       "forbid_deletion": true,
-      "pinned_sha": "ab8960d2e8e04cf91c684e2e5b2471f53ca5bb19"
+      "pinned_sha": "a5962debed4f94ca19ecf8ed87346b35568c0d64"
     }
   ]
 }


### PR DESCRIPTION
Automated workspace manifest SHA refresh.

- Changed repos: 3
- Source workflow: `Workspace SHA Refresh PR`
- Run: https://github.com/svelderrainruiz/labview-cdev-surface/actions/runs/25164254360
- Merge strategy: squash auto-merge